### PR TITLE
Add YAML multiline support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "swagger-autogen": "2.23.7",
         "swagger-ui-express": "5.0.1",
         "uuid": "10.0.0",
-        "winston": "3.17.0"
+        "winston": "3.17.0",
+        "yaml": "^2.3.4"
       },
       "devDependencies": {
         "@types/cookie": "0.6.0",
@@ -38,6 +39,7 @@
         "@types/lodash": "4.17.19",
         "@types/node": "20.14.2",
         "@types/uuid": "10.0.0",
+        "@types/ws": "8.18.1",
         "builtin-modules": "5.0.0",
         "cross-env": "7.0.3",
         "eslint-config-prettier": "9.0.0",
@@ -8495,6 +8497,17 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "swagger-autogen": "2.23.7",
     "swagger-ui-express": "5.0.1",
     "uuid": "10.0.0",
-    "winston": "3.17.0"
+    "winston": "3.17.0",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@types/cookie": "0.6.0",

--- a/src/endpoints/forms/formSync/utils/multilineHandler.ts
+++ b/src/endpoints/forms/formSync/utils/multilineHandler.ts
@@ -1,0 +1,105 @@
+import * as yaml from 'yaml'
+
+/**
+ * Processes multiline strings in YAML to ensure they are properly formatted
+ * @param yamlContent - The YAML content as string
+ * @returns Processed YAML content with proper multiline formatting
+ */
+export const processMultilineInYaml = (yamlContent: string): string => {
+  try {
+    // Parse the YAML to get the object structure
+    const parsed = yaml.parse(yamlContent)
+    
+    // Convert back to YAML with proper multiline formatting
+    const processed = yaml.stringify(parsed, {
+      // Use literal block scalar (|) for multiline strings
+      blockQuote: 'literal',
+      // Preserve line breaks
+      lineWidth: 0,
+      // Use double quotes for strings that need escaping
+      doubleQuotedAsJSON: false,
+      // Use literal block scalar for multiline strings
+      defaultStringType: 'QUOTE_DOUBLE',
+    })
+    
+    return processed
+  } catch (error) {
+    // If parsing fails, return original content
+    console.warn('Failed to process multiline YAML:', error)
+    return yamlContent
+  }
+}
+
+/**
+ * Processes form values to ensure multiline strings are properly handled
+ * @param values - The form values object
+ * @returns Processed values with multiline strings properly formatted
+ */
+export const processMultilineInFormValues = (values: any): any => {
+  if (!values || typeof values !== 'object') {
+    return values
+  }
+
+  const processed = { ...values }
+
+  const processObject = (obj: any): any => {
+    if (typeof obj === 'string') {
+      // Check if this string should be multiline
+      if (obj.includes('\n') || obj.length > 80) {
+        return obj
+      }
+      return obj
+    }
+
+    if (Array.isArray(obj)) {
+      return obj.map(processObject)
+    }
+
+    if (obj && typeof obj === 'object') {
+      const result: any = {}
+      for (const [key, value] of Object.entries(obj)) {
+        result[key] = processObject(value)
+      }
+      return result
+    }
+
+    return obj
+  }
+
+  return processObject(processed)
+}
+
+/**
+ * Detects if a string value should be treated as multiline
+ * @param value - The string value to check
+ * @returns true if the value should be multiline
+ */
+export const shouldBeMultiline = (value: string): boolean => {
+  if (!value || typeof value !== 'string') {
+    return false
+  }
+
+  // Check for newlines
+  if (value.includes('\n')) {
+    return true
+  }
+
+  // Check for long strings
+  if (value.length > 80) {
+    return true
+  }
+
+  // Check for multiline indicators
+  const multilineIndicators = [
+    '#cloud-config',
+    '#!/',
+    '---',
+    '```',
+    'BEGIN',
+    'END',
+    '-----BEGIN',
+    '-----END',
+  ]
+
+  return multilineIndicators.some(indicator => value.includes(indicator))
+}

--- a/src/endpoints/forms/formSync/utils/onValuesChange.ts
+++ b/src/endpoints/forms/formSync/utils/onValuesChange.ts
@@ -2,6 +2,7 @@ import { OpenAPIV2 } from 'openapi-types'
 import { TFormName } from 'src/localTypes/forms'
 import { removeEmptyFormValues, renameBrokenFieldBack } from './removeAndRename'
 import { normalizeValuesForQuotas } from './normalizeQuotas'
+import { processMultilineInFormValues } from './multilineHandler'
 
 export const onValuesChange = ({
   values,
@@ -15,5 +16,6 @@ export const onValuesChange = ({
   const cleanSchema = removeEmptyFormValues(values, persistedKeys)
   const fixedCleanSchema = renameBrokenFieldBack(cleanSchema)
   const quotasFixedSchema = normalizeValuesForQuotas(fixedCleanSchema, properties)
-  return quotasFixedSchema
+  const multilineProcessedSchema = processMultilineInFormValues(quotasFixedSchema)
+  return multilineProcessedSchema
 }

--- a/src/endpoints/forms/formSync/utils/onYamlChange.ts
+++ b/src/endpoints/forms/formSync/utils/onYamlChange.ts
@@ -1,6 +1,7 @@
 import { OpenAPIV2 } from 'openapi-types'
 import { renameBrokenFieldBackToFormAgain } from './removeAndRename'
 import { normalizeValuesForQuotasToNumber } from './normalizeQuotas'
+import { processMultilineInYaml } from './multilineHandler'
 
 export const onYamlChange = ({
   values,


### PR DESCRIPTION
Link https://github.com/PRO-Robotech/openapi-k8s-toolkit/pull/171

Video:

https://github.com/user-attachments/assets/1f38e380-040e-482f-a9f3-cd219aed76ae

Example resource:

```yaml
kind: VirtualMachine
metadata:
  creationTimestamp: "2025-09-23T16:00:14Z"
  name: vm
  namespace: tenant-kvaps
  resourceVersion: "210202296"
  uid: 2d1ef591-fa2d-45ff-8d7a-e64496349b06
spec:
  cloudInit: |
    #cloud-config
    password: atomic
    chpasswd: { expire: False }
    ssh_pwauth: False
  cloudInitSeed: asdfsdf
  external: false
  externalMethod: PortList
  externalPorts:
  - 22
  gpus: []
  instanceProfile: ubuntu
  instanceType: u1.medium
  resources: {}
  running: true
  sshKeys: []
  systemDisk:
    image: ubuntu
    storage: 5Gi
    storageClass: replicated
```
