### PR TITLE
[CLOUD-60]: rollback action copies the kubectl request flow

### DIFF
--- a/src/endpoints/actions/drain/drain.test.ts
+++ b/src/endpoints/actions/drain/drain.test.ts
@@ -1,0 +1,230 @@
+import { drain } from './drain'
+import { userKubeApi } from 'src/constants/httpAgent'
+import type { Request, Response } from 'express'
+
+jest.mock('src/constants/httpAgent', () => ({
+  userKubeApi: { get: jest.fn(), patch: jest.fn(), post: jest.fn() },
+}))
+
+jest.mock('src/constants/envs', () => ({ DEVELOPMENT: true }))
+jest.mock('src/utils/filterHeadersFromEnv', () => ({ filterHeadersFromEnv: () => ({}) }))
+
+const mockedGet = userKubeApi.get as jest.Mock
+const mockedPatch = userKubeApi.patch as jest.Mock
+const mockedPost = userKubeApi.post as jest.Mock
+
+function makeReq(body: Record<string, unknown> = {}) {
+  return { body, headers: {} } as unknown as Request
+}
+
+function makeRes() {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as Response
+  return res
+}
+
+function makePod(name: string, namespace: string, opts: { phase?: string; mirror?: boolean; ownerKind?: string } = {}) {
+  return {
+    metadata: {
+      name,
+      namespace,
+      ...(opts.mirror ? { annotations: { 'kubernetes.io/config.mirror': 'true' } } : {}),
+      ...(opts.ownerKind ? { ownerReferences: [{ kind: opts.ownerKind }] } : {}),
+    },
+    ...(opts.phase ? { status: { phase: opts.phase } } : {}),
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('drain', () => {
+  it('returns 400 when nodeName is missing', async () => {
+    const res = makeRes()
+    await drain(makeReq({ apiPath: '/api/v1/nodes/node1' }), res, jest.fn())
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('required') }))
+  })
+
+  it('returns 400 when apiPath is missing', async () => {
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1' }), res, jest.fn())
+    expect(res.status).toHaveBeenCalledWith(400)
+  })
+
+  it('cordons the node first', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+    mockedGet.mockResolvedValueOnce({ data: { items: [] } })
+
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1', apiPath: '/api/v1/nodes/node1' }), res, jest.fn())
+
+    expect(mockedPatch).toHaveBeenCalledWith(
+      '/api/v1/nodes/node1',
+      { spec: { unschedulable: true } },
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'Content-Type': 'application/strategic-merge-patch+json' }),
+      }),
+    )
+  })
+
+  it('skips Succeeded and Failed pods', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        items: [
+          makePod('pod-ok', 'default'),
+          makePod('pod-succeeded', 'default', { phase: 'Succeeded' }),
+          makePod('pod-failed', 'default', { phase: 'Failed' }),
+        ],
+      },
+    })
+    mockedPost.mockResolvedValue({ data: {} })
+
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1', apiPath: '/api/v1/nodes/node1' }), res, jest.fn())
+
+    expect(mockedPost).toHaveBeenCalledTimes(1)
+    expect(res.json).toHaveBeenCalledWith({ drained: 1, failed: [], skipped: 2 })
+  })
+
+  it('skips mirror pods', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        items: [makePod('pod-ok', 'default'), makePod('pod-mirror', 'default', { mirror: true })],
+      },
+    })
+    mockedPost.mockResolvedValue({ data: {} })
+
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1', apiPath: '/api/v1/nodes/node1' }), res, jest.fn())
+
+    expect(mockedPost).toHaveBeenCalledTimes(1)
+    expect(res.json).toHaveBeenCalledWith({ drained: 1, failed: [], skipped: 1 })
+  })
+
+  it('skips DaemonSet pods when ignoreDaemonSets is true (default)', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        items: [makePod('pod-ok', 'default'), makePod('pod-ds', 'default', { ownerKind: 'DaemonSet' })],
+      },
+    })
+    mockedPost.mockResolvedValue({ data: {} })
+
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1', apiPath: '/api/v1/nodes/node1' }), res, jest.fn())
+
+    expect(mockedPost).toHaveBeenCalledTimes(1)
+    expect(res.json).toHaveBeenCalledWith({ drained: 1, failed: [], skipped: 1 })
+  })
+
+  it('does NOT skip DaemonSet pods when ignoreDaemonSets is false', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        items: [makePod('pod-ok', 'default'), makePod('pod-ds', 'default', { ownerKind: 'DaemonSet' })],
+      },
+    })
+    mockedPost.mockResolvedValue({ data: {} })
+
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1', apiPath: '/api/v1/nodes/node1', ignoreDaemonSets: false }), res, jest.fn())
+
+    expect(mockedPost).toHaveBeenCalledTimes(2)
+    expect(res.json).toHaveBeenCalledWith({ drained: 2, failed: [], skipped: 0 })
+  })
+
+  it('includes gracePeriodSeconds in eviction body when provided', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+    mockedGet.mockResolvedValueOnce({ data: { items: [makePod('pod1', 'ns1')] } })
+    mockedPost.mockResolvedValue({ data: {} })
+
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1', apiPath: '/api/v1/nodes/node1', gracePeriodSeconds: 30 }), res, jest.fn())
+
+    const evictionBody = mockedPost.mock.calls[0][1]
+    expect(evictionBody.deleteOptions).toEqual({ gracePeriodSeconds: 30 })
+  })
+
+  it('does NOT include deleteOptions when gracePeriodSeconds is not provided', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+    mockedGet.mockResolvedValueOnce({ data: { items: [makePod('pod1', 'ns1')] } })
+    mockedPost.mockResolvedValue({ data: {} })
+
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1', apiPath: '/api/v1/nodes/node1' }), res, jest.fn())
+
+    const evictionBody = mockedPost.mock.calls[0][1]
+    expect(evictionBody.deleteOptions).toBeUndefined()
+  })
+
+  it('sends correct eviction request per pod', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+    mockedGet.mockResolvedValueOnce({
+      data: { items: [makePod('pod1', 'ns1'), makePod('pod2', 'ns2')] },
+    })
+    mockedPost.mockResolvedValue({ data: {} })
+
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1', apiPath: '/api/v1/nodes/node1' }), res, jest.fn())
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/api/v1/namespaces/ns1/pods/pod1/eviction',
+      expect.objectContaining({
+        apiVersion: 'policy/v1',
+        kind: 'Eviction',
+        metadata: { name: 'pod1', namespace: 'ns1' },
+      }),
+      expect.any(Object),
+    )
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/api/v1/namespaces/ns2/pods/pod2/eviction',
+      expect.objectContaining({ metadata: { name: 'pod2', namespace: 'ns2' } }),
+      expect.any(Object),
+    )
+  })
+
+  it('reports partial failures correctly', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+    mockedGet.mockResolvedValueOnce({
+      data: { items: [makePod('pod-ok', 'ns1'), makePod('pod-fail', 'ns1')] },
+    })
+    mockedPost.mockResolvedValueOnce({ data: {} }).mockRejectedValueOnce(new Error('forbidden'))
+
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1', apiPath: '/api/v1/nodes/node1' }), res, jest.fn())
+
+    expect(res.json).toHaveBeenCalledWith({
+      drained: 1,
+      failed: [{ name: 'pod-fail', namespace: 'ns1', error: 'forbidden' }],
+      skipped: 0,
+    })
+  })
+
+  it('returns 500 when cordon patch fails', async () => {
+    mockedPatch.mockRejectedValueOnce(new Error('unauthorized'))
+
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1', apiPath: '/api/v1/nodes/node1' }), res, jest.fn())
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'unauthorized' }))
+  })
+
+  it('handles empty pod list', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+    mockedGet.mockResolvedValueOnce({ data: { items: [] } })
+
+    const res = makeRes()
+    await drain(makeReq({ nodeName: 'node1', apiPath: '/api/v1/nodes/node1' }), res, jest.fn())
+
+    expect(mockedPost).not.toHaveBeenCalled()
+    expect(res.json).toHaveBeenCalledWith({ drained: 0, failed: [], skipped: 0 })
+  })
+})

--- a/src/endpoints/actions/rollback/rollback.test.ts
+++ b/src/endpoints/actions/rollback/rollback.test.ts
@@ -1,0 +1,215 @@
+import { rollback } from './rollback'
+import { userKubeApi } from 'src/constants/httpAgent'
+import type { Request, Response } from 'express'
+
+jest.mock('src/constants/httpAgent', () => ({
+  userKubeApi: { get: jest.fn(), patch: jest.fn() },
+}))
+
+jest.mock('src/constants/envs', () => ({ DEVELOPMENT: true }))
+jest.mock('src/utils/filterHeadersFromEnv', () => ({ filterHeadersFromEnv: () => ({}) }))
+
+const mockedGet = userKubeApi.get as jest.Mock
+const mockedPatch = userKubeApi.patch as jest.Mock
+
+function makeReq(body: Record<string, unknown> = {}) {
+  return { body, headers: {} } as unknown as Request
+}
+
+function makeRes() {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as Response
+  return res
+}
+
+function makeDeployment(revision: number, uid = 'deploy-uid-1') {
+  return {
+    apiVersion: 'apps/v1',
+    metadata: {
+      name: 'my-deploy',
+      namespace: 'default',
+      uid,
+      annotations: { 'deployment.kubernetes.io/revision': String(revision) },
+    },
+    spec: {
+      selector: { matchLabels: { app: 'my-deploy' } as Record<string, string> },
+    },
+  }
+}
+
+function makeRS(name: string, revision: number, ownerUid: string, template: Record<string, unknown> = {}) {
+  return {
+    metadata: {
+      name,
+      annotations: { 'deployment.kubernetes.io/revision': String(revision) },
+      ownerReferences: [{ uid: ownerUid, kind: 'Deployment', name: 'my-deploy' }],
+    },
+    spec: { template },
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('rollback', () => {
+  it('returns 400 when resourceEndpoint is missing', async () => {
+    const res = makeRes()
+    await rollback(makeReq({ resourceName: 'x' }), res, jest.fn())
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('required') }))
+  })
+
+  it('returns 400 when resourceName is missing', async () => {
+    const res = makeRes()
+    await rollback(makeReq({ resourceEndpoint: '/apis/apps/v1/namespaces/default/deployments/x' }), res, jest.fn())
+    expect(res.status).toHaveBeenCalledWith(400)
+  })
+
+  it('returns 400 when current revision is 1', async () => {
+    mockedGet.mockResolvedValueOnce({ data: makeDeployment(1) })
+    const res = makeRes()
+    await rollback(
+      makeReq({ resourceEndpoint: '/apis/apps/v1/namespaces/default/deployments/x', resourceName: 'x' }),
+      res,
+      jest.fn(),
+    )
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining('No previous revision') }),
+    )
+  })
+
+  it('returns 400 when deployment has no matchLabels', async () => {
+    const deploy = makeDeployment(3)
+    deploy.spec.selector.matchLabels = {} as Record<string, string>
+    mockedGet.mockResolvedValueOnce({ data: deploy })
+    const res = makeRes()
+    await rollback(
+      makeReq({ resourceEndpoint: '/apis/apps/v1/namespaces/default/deployments/x', resourceName: 'x' }),
+      res,
+      jest.fn(),
+    )
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('matchLabels') }))
+  })
+
+  it('filters out ReplicaSets not owned by this Deployment', async () => {
+    const deploy = makeDeployment(3)
+    const ownedRS = makeRS('rs-owned', 2, 'deploy-uid-1', { spec: { containers: [{ image: 'nginx:1.24' }] } })
+    const foreignRS = makeRS('rs-foreign', 2, 'other-deploy-uid', { spec: { containers: [{ image: 'nginx:1.20' }] } })
+
+    mockedGet.mockResolvedValueOnce({ data: deploy }).mockResolvedValueOnce({ data: { items: [ownedRS, foreignRS] } })
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+
+    const res = makeRes()
+    await rollback(
+      makeReq({ resourceEndpoint: '/apis/apps/v1/namespaces/default/deployments/x', resourceName: 'x' }),
+      res,
+      jest.fn(),
+    )
+
+    // Should have patched with the owned RS's template, not the foreign one
+    const patchBody = mockedPatch.mock.calls[0][1]
+    expect(patchBody[0].value).toEqual(ownedRS.spec.template)
+  })
+
+  it('handles non-contiguous revisions (picks highest below current)', async () => {
+    const deploy = makeDeployment(5)
+    const rs1 = makeRS('rs-1', 1, 'deploy-uid-1', { v: 1 })
+    const rs3 = makeRS('rs-3', 3, 'deploy-uid-1', { v: 3 })
+    // Revision 4 is missing (garbage-collected)
+
+    mockedGet.mockResolvedValueOnce({ data: deploy }).mockResolvedValueOnce({ data: { items: [rs1, rs3] } })
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+
+    const res = makeRes()
+    await rollback(
+      makeReq({ resourceEndpoint: '/apis/apps/v1/namespaces/default/deployments/x', resourceName: 'x' }),
+      res,
+      jest.fn(),
+    )
+
+    // Should pick revision 3, not try revision 4
+    expect(res.json).toHaveBeenCalledWith({ rolledBack: true, fromRevision: 5, toRevision: 3 })
+    expect(mockedPatch.mock.calls[0][1][0].value).toEqual({ v: 3 })
+  })
+
+  it('returns 400 when no previous RS revision exists', async () => {
+    const deploy = makeDeployment(3)
+    // Only RS with current revision, nothing lower
+    const currentRS = makeRS('rs-current', 3, 'deploy-uid-1', {})
+
+    mockedGet.mockResolvedValueOnce({ data: deploy }).mockResolvedValueOnce({ data: { items: [currentRS] } })
+
+    const res = makeRes()
+    await rollback(
+      makeReq({ resourceEndpoint: '/apis/apps/v1/namespaces/default/deployments/x', resourceName: 'x' }),
+      res,
+      jest.fn(),
+    )
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('No previous') }))
+  })
+
+  it('sends JSON Patch with two replace operations (matches kubectl)', async () => {
+    const deploy = makeDeployment(3)
+    const prevRS = makeRS('rs-prev', 2, 'deploy-uid-1', {
+      metadata: { labels: { app: 'my-deploy' } },
+      spec: { containers: [{ name: 'nginx', image: 'nginx:1.24' }] },
+    })
+
+    mockedGet.mockResolvedValueOnce({ data: deploy }).mockResolvedValueOnce({ data: { items: [prevRS] } })
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+
+    const res = makeRes()
+    await rollback(
+      makeReq({ resourceEndpoint: '/apis/apps/v1/namespaces/default/deployments/x', resourceName: 'x' }),
+      res,
+      jest.fn(),
+    )
+
+    // Verify JSON Patch format
+    const [url, body, config] = mockedPatch.mock.calls[0]
+    expect(url).toBe('/apis/apps/v1/namespaces/default/deployments/x')
+    expect(config.headers['Content-Type']).toBe('application/json-patch+json')
+    expect(body).toHaveLength(2)
+    expect(body[0]).toEqual({ op: 'replace', path: '/spec/template', value: prevRS.spec.template })
+    expect(body[1]).toEqual({ op: 'replace', path: '/metadata/annotations', value: deploy.metadata.annotations })
+  })
+
+  it('returns correct response on success', async () => {
+    const deploy = makeDeployment(4)
+    const prevRS = makeRS('rs-prev', 3, 'deploy-uid-1', { spec: {} })
+
+    mockedGet.mockResolvedValueOnce({ data: deploy }).mockResolvedValueOnce({ data: { items: [prevRS] } })
+    mockedPatch.mockResolvedValueOnce({ data: {} })
+
+    const res = makeRes()
+    await rollback(
+      makeReq({ resourceEndpoint: '/apis/apps/v1/namespaces/default/deployments/x', resourceName: 'x' }),
+      res,
+      jest.fn(),
+    )
+
+    expect(res.json).toHaveBeenCalledWith({ rolledBack: true, fromRevision: 4, toRevision: 3 })
+  })
+
+  it('returns 500 when K8s API throws', async () => {
+    mockedGet.mockRejectedValueOnce(new Error('connection refused'))
+
+    const res = makeRes()
+    await rollback(
+      makeReq({ resourceEndpoint: '/apis/apps/v1/namespaces/default/deployments/x', resourceName: 'x' }),
+      res,
+      jest.fn(),
+    )
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'connection refused' }))
+  })
+})

--- a/src/endpoints/actions/rollback/rollback.ts
+++ b/src/endpoints/actions/rollback/rollback.ts
@@ -14,6 +14,11 @@ type TReplicaSet = {
   metadata: {
     name: string
     annotations?: Record<string, string>
+    ownerReferences?: Array<{
+      uid: string
+      kind: string
+      name: string
+    }>
   }
   spec: {
     template: Record<string, unknown>
@@ -34,7 +39,7 @@ export const rollback: RequestHandler = async (req: TRollbackRequest & Request, 
   }
   const patchHeaders = {
     ...(DEVELOPMENT ? {} : filteredHeaders),
-    'Content-Type': 'application/strategic-merge-patch+json',
+    'Content-Type': 'application/json-patch+json',
   }
 
   try {
@@ -71,28 +76,50 @@ export const rollback: RequestHandler = async (req: TRollbackRequest & Request, 
       headers: jsonHeaders,
     })
 
-    // Step 4: Find the RS with the previous revision
-    const targetRevision = currentRevision - 1
-    const previousRS = rsList.items?.find(rs => {
-      const rsRevision = parseInt(rs.metadata.annotations?.['deployment.kubernetes.io/revision'] || '0', 10)
-      return rsRevision === targetRevision
-    })
+    // Step 4: Filter RSes by ownerReference to this Deployment
+    const deploymentUid = deployment.metadata?.uid
+    const ownedRSes =
+      rsList.items?.filter(
+        rs => rs.metadata.ownerReferences?.some(ref => ref.uid === deploymentUid && ref.kind === 'Deployment'),
+      ) || []
 
-    if (!previousRS) {
-      return res.status(400).json({ error: `No ReplicaSet found with revision ${targetRevision}` })
+    // Step 5: Find the RS with the highest revision below current (handles gaps)
+    const revisionsDescending = ownedRSes
+      .map(rs => ({
+        rs,
+        revision: parseInt(rs.metadata.annotations?.['deployment.kubernetes.io/revision'] || '0', 10),
+      }))
+      .filter(({ revision }) => revision < currentRevision && revision > 0)
+      .sort((a, b) => b.revision - a.revision)
+
+    const previous = revisionsDescending[0]
+
+    if (!previous) {
+      return res.status(400).json({ error: 'No previous ReplicaSet revision found to rollback to' })
     }
 
-    // Step 5: Patch the Deployment's spec.template with the previous RS's template
+    // Step 6: Patch the Deployment using JSON Patch (matches kubectl rollout undo)
     await userKubeApi.patch(
       resourceEndpoint,
-      { spec: { template: previousRS.spec.template } },
+      [
+        {
+          op: 'replace',
+          path: '/spec/template',
+          value: previous.rs.spec.template,
+        },
+        {
+          op: 'replace',
+          path: '/metadata/annotations',
+          value: deployment.metadata?.annotations || {},
+        },
+      ],
       { headers: patchHeaders },
     )
 
     return res.json({
       rolledBack: true,
       fromRevision: currentRevision,
-      toRevision: targetRevision,
+      toRevision: previous.revision,
     })
   } catch (error) {
     console.error('[rollback] Error:', {


### PR DESCRIPTION
  - JSON Patch instead of Strategic Merge Patch — switched to application/json-patch+json with two replace operations (/spec/template and /metadata/annotations), matching the exact PATCH request kubectl sends                                                                          
  - ownerReferences filtering — ReplicaSets are now filtered by ownerReferences to ensure only RSes owned by the target Deployment are considered
  - Non-contiguous revision handling — instead of naively picking currentRevision - 1, we now select the highest revision below current, handling gaps from garbage-collected ReplicaSets
  - Added unit tests for both rollback (10 tests) and drain (13 tests) endpoints