### PR TITLE
[CLOUD-423]: WS error logs filtering via env

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -18,6 +18,9 @@ BASE_NAMESPACE_FULL_PATH=
 
 BASE_ALLOWED_AUTH_HEADERS=
 
+WS_LOG_WHITELIST_PATHS=
+WS_LOG_BLACKLIST_PATHS=
+
 # '{
 #   "plugin-example": {
 #     "name": "plugin-example",

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This app can be configured through environment variables.
 | `BASE_NAMESPACE_FACTORY_KEY`             | `string` | Base factory key for namespace                              |
 | `BASE_NAMESPACE_FULL_PATH`               | `string` | Resrouce full path if you use custom API resource for NS    |
 | `BASE_ALLOWED_AUTH_HEADERS`              | `string` | White-listed req headers for impersonation                  |
+| `WS_LOG_WHITELIST_PATHS`                 | `string` | JSON array of WS log field paths to keep                    |
+| `WS_LOG_BLACKLIST_PATHS`                 | `string` | JSON array of WS log field paths to remove                  |
 | `MF_PLUGINS_NO_CLUSTER`                  | `string` | JSON for Plugins Manifest                                   |
 
 Local development: This app can be also configured through more environment variables.
@@ -33,6 +35,24 @@ Local development: This app can be also configured through more environment vari
 | `DEV_KUBE_API_URL`        | `string` | Full url to k8s proxy inside nginx inside port-forwarded container |
 | `KUBERNETES_SERVICE_HOST` | `string` | Host from API url above                                            |
 | `KUBERNETES_SERVICE_PORT` | `string` | Port from API url above                                            |
+
+### WebSocket log filtering
+
+WebSocket handlers in this BFF use plain `console.*` logs, while `winston` / `express-winston` only handle HTTP request logging. If you need to trim sensitive fields from WS log payloads, configure one of these env vars:
+
+- `WS_LOG_WHITELIST_PATHS`: JSON array of dot-paths to keep. If set, only these fields/subtrees are logged.
+- `WS_LOG_BLACKLIST_PATHS`: JSON array of dot-paths to remove. Used only when whitelist is empty.
+
+Rules:
+
+- If neither env is set, WS logs keep their current payloads.
+- If both are set, whitelist wins.
+- Invalid JSON is ignored with a warning.
+
+Examples:
+
+- `WS_LOG_BLACKLIST_PATHS=["error.config.headers.authorization","headers.cookie"]`
+- `WS_LOG_WHITELIST_PATHS=["error.message","error.code","headers.x-request-id"]`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This app can be configured through environment variables.
 | `BASE_FACTORY_NAMESPACED_BUILTIN_KEY`    | `string` | Base factory key for namespaced api/v1 resource             |
 | `BASE_FACTORY_CLUSTERSCOPED_BUILTIN_KEY` | `string` | Base factory key for clusterscoped api/v1 resource          |
 | `BASE_NAMESPACE_FACTORY_KEY`             | `string` | Base factory key for namespace                              |
-| `BASE_NAMESPACE_FULL_PATH`               | `string` | Resrouce full path if you use custom API resource for NS    |
+| `BASE_NAMESPACE_FULL_PATH`               | `string` | Resource full path if you use custom API resource for NS    |
 | `BASE_ALLOWED_AUTH_HEADERS`              | `string` | White-listed req headers for impersonation                  |
 | `WS_LOG_WHITELIST_PATHS`                 | `string` | JSON array of WS log field paths to keep                    |
 | `WS_LOG_BLACKLIST_PATHS`                 | `string` | JSON array of WS log field paths to remove                  |
@@ -48,11 +48,18 @@ Rules:
 - If neither env is set, WS logs keep their current payloads.
 - If both are set, whitelist wins.
 - Invalid JSON is ignored with a warning.
+- Paths support wildcards: `*` matches exactly one segment, `**` matches zero or more segments.
 
 Examples:
 
-- `WS_LOG_BLACKLIST_PATHS=["error.config.headers.authorization","headers.cookie"]`
+- `WS_LOG_BLACKLIST_PATHS=["error.config.headers.authorization","headers.authorization","headers.cookie"]`
 - `WS_LOG_WHITELIST_PATHS=["error.message","error.code","headers.x-request-id"]`
+
+Wildcard examples:
+
+- `WS_LOG_BLACKLIST_PATHS=["**.authorization","**.cookie"]` — strips `authorization` and `cookie` at any depth
+- `WS_LOG_BLACKLIST_PATHS=["*.authorization"]` — strips `authorization` only one level deep (e.g. `headers.authorization` but not `error.config.headers.authorization`)
+- `WS_LOG_WHITELIST_PATHS=["**.message","**.status"]` — keeps only `message` and `status` fields wherever they appear
 
 ---
 

--- a/src/constants/envs.test.ts
+++ b/src/constants/envs.test.ts
@@ -1,0 +1,23 @@
+describe('parseJsonEnvStringArray', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('returns parsed string arrays', async () => {
+    const { parseJsonEnvStringArray } = await import('src/utils/parseJsonEnvStringArray')
+
+    expect(parseJsonEnvStringArray('["error.message","headers.authorization"]', 'TEST_ENV')).toEqual([
+      'error.message',
+      'headers.authorization',
+    ])
+  })
+
+  test('warns and returns empty array for malformed JSON', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const { parseJsonEnvStringArray } = await import('src/utils/parseJsonEnvStringArray')
+
+    expect(parseJsonEnvStringArray('{"error":"message"}', 'TEST_ENV')).toEqual([])
+    expect(parseJsonEnvStringArray('[oops', 'TEST_ENV')).toEqual([])
+    expect(warnSpy).toHaveBeenCalled()
+  })
+})

--- a/src/constants/envs.ts
+++ b/src/constants/envs.ts
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv'
+import { parseJsonEnvStringArray } from 'src/utils/parseJsonEnvStringArray'
 
 dotenv.config()
 
@@ -26,3 +27,13 @@ export const BASE_NAMESPACE_FACTORY_KEY = process.env.BASE_NAMESPACE_FACTORY_KEY
 export const BASE_NAMESPACE_FULL_PATH = process.env.BASE_NAMESPACE_FULL_PATH || '/api/v1/namespaces'
 
 export const BASE_ALLOWED_AUTH_HEADERS = process.env.BASE_ALLOWED_AUTH_HEADERS || ''
+
+export const WS_LOG_WHITELIST_PATHS = parseJsonEnvStringArray(
+  process.env.WS_LOG_WHITELIST_PATHS,
+  'WS_LOG_WHITELIST_PATHS',
+)
+export const WS_LOG_BLACKLIST_PATHS = parseJsonEnvStringArray(
+  process.env.WS_LOG_BLACKLIST_PATHS,
+  'WS_LOG_BLACKLIST_PATHS',
+)
+export const WS_LOG_PATH_FILTERS_ENABLED = WS_LOG_WHITELIST_PATHS.length > 0 || WS_LOG_BLACKLIST_PATHS.length > 0

--- a/src/endpoints/events/eventsWs/eventsWebSocket.ts
+++ b/src/endpoints/events/eventsWs/eventsWebSocket.ts
@@ -5,6 +5,7 @@ import { WebsocketRequestHandler } from 'express-ws'
 import { DEVELOPMENT } from 'src/constants/envs'
 import { userKubeApi } from 'src/constants/httpAgent'
 import { filterHeadersFromEnv } from 'src/utils/filterHeadersFromEnv'
+import { formatWsLogInput, getWsRawMessageMetadata, sanitizeWsLogPayload } from 'src/utils/wsLogSanitizer'
 import { eventSortKey } from './utils'
 import { TWatchPhase, TEventsV1Event } from './types'
 import { normalizeWsError } from './utils/normalizeWsError'
@@ -71,13 +72,16 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
   const fieldSelector = safeDecode(fieldSelectorRaw)
   const labelSelector = safeDecode(labelSelectorRaw)
 
-  console.log(`[${new Date().toISOString()}]: Query params parsed:`, {
-    namespace,
-    initialLimit,
-    initialContinue,
-    sinceRV,
-  })
-  console.log(`[${new Date().toISOString()}]: Selectors:`, { fieldSelector, labelSelector })
+  console.log(
+    `[${new Date().toISOString()}]: Query params parsed:`,
+    sanitizeWsLogPayload({
+      namespace,
+      initialLimit,
+      initialContinue,
+      sinceRV,
+    }),
+  )
+  console.log(`[${new Date().toISOString()}]: Selectors:`, sanitizeWsLogPayload({ fieldSelector, labelSelector }))
 
   let closed = false
   // Seed lastRV from client if provided (so we can resume)
@@ -159,7 +163,10 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
     _continue?: string
     captureRV: boolean
   }) => {
-    console.log(`[${new Date().toISOString()}]: Listing page of events`, { limit, _continue, captureRV, lastRV })
+    console.log(
+      `[${new Date().toISOString()}]: Listing page of events`,
+      sanitizeWsLogPayload({ limit, _continue, captureRV, lastRV }),
+    )
 
     const filteredHeaders = filterHeadersFromEnv(req)
     const qs = buildListQS({
@@ -182,11 +189,14 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
     const meta = body?.metadata || {}
     const cont = (meta.continue ?? meta._continue) as string | undefined
 
-    console.log(`[${new Date().toISOString()}]: List page received`, {
-      itemCount: items.length,
-      continue: cont,
-      resourceVersion: meta.resourceVersion,
-    })
+    console.log(
+      `[${new Date().toISOString()}]: List page received`,
+      sanitizeWsLogPayload({
+        itemCount: items.length,
+        continue: cont,
+        resourceVersion: meta.resourceVersion,
+      }),
+    )
 
     if (captureRV) lastRV = meta.resourceVersion
     return {
@@ -218,17 +228,27 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
           ws.send(JSON.stringify({ type: p, item: obj }))
         }
       } catch (error) {
-        console.warn(`[${new Date().toISOString()}]: Failed to send event:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error,
-        })
+        console.warn(
+          `[${new Date().toISOString()}]: Failed to send event:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error,
+          }),
+        )
       }
     }
   }
 
   const onError = async (err: unknown) => {
-    console.error(`[${new Date().toISOString()}]: Watch error:`, err)
+    console.error(
+      `[${new Date().toISOString()}]: Watch error:`,
+      sanitizeWsLogPayload({
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+        error: err,
+      }),
+    )
     if (closed) return
     const normalizedError = normalizeWsError(err, 'Watch error')
     const reasonSuffix = normalizedError.reason ? ` ${normalizedError.reason}` : ''
@@ -243,11 +263,14 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
       try {
         await listPage({ limit: initialLimit, _continue: undefined, captureRV: true })
       } catch (error) {
-        console.error(`[${new Date().toISOString()}]: Failed to reset listPage after 410:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error,
-        })
+        console.error(
+          `[${new Date().toISOString()}]: Failed to reset listPage after 410:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error,
+          }),
+        )
       }
     }
     // Restart the watch after a short delay; ensure we stop the current one first
@@ -320,16 +343,26 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
             }
             if (phase) onEvent(phase, obj)
           } catch (error) {
-            console.warn(`[${new Date().toISOString()}]: Failed to parse watch event line`, {
-              message: error instanceof Error ? error.message : String(error),
-              line,
-            })
+            console.warn(
+              `[${new Date().toISOString()}]: Failed to parse watch event line`,
+              sanitizeWsLogPayload({
+                message: error instanceof Error ? error.message : String(error),
+                line,
+              }),
+            )
           }
         }
       }
 
       const onStreamError = (error: unknown) => {
-        console.error(`[${new Date().toISOString()}]: Watch stream error:`, error)
+        console.error(
+          `[${new Date().toISOString()}]: Watch stream error:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error,
+          }),
+        )
         void onError(error)
       }
 
@@ -352,11 +385,14 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
         }
       }
     } catch (error) {
-      console.error(`[${new Date().toISOString()}]: Error starting watch:`, {
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-        error,
-      })
+      console.error(
+        `[${new Date().toISOString()}]: Error starting watch:`,
+        sanitizeWsLogPayload({
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+          error,
+        }),
+      )
       const normalizedError = normalizeWsError(error, 'Error starting watch')
       const reasonSuffix = normalizedError.reason ? ` ${normalizedError.reason}` : ''
       sendServerLog(
@@ -371,7 +407,14 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
         try {
           await listPage({ limit: initialLimit, _continue: undefined, captureRV: true })
         } catch (e) {
-          console.error(`[${new Date().toISOString()}]: Failed re-list after 410:`, e)
+          console.error(
+            `[${new Date().toISOString()}]: Failed re-list after 410:`,
+            sanitizeWsLogPayload({
+              message: e instanceof Error ? e.message : String(e),
+              stack: e instanceof Error ? e.stack : undefined,
+              error: e,
+            }),
+          )
         }
       }
 
@@ -404,19 +447,25 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
           }),
         )
       } catch (error) {
-        console.error(`[${new Date().toISOString()}]: Failed to send INITIAL page:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error,
-        })
+        console.error(
+          `[${new Date().toISOString()}]: Failed to send INITIAL page:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error,
+          }),
+        )
       }
     }
   } catch (error) {
-    console.error(`[${new Date().toISOString()}]: Initial list failed:`, {
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-      error,
-    })
+    console.error(
+      `[${new Date().toISOString()}]: Initial list failed:`,
+      sanitizeWsLogPayload({
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        error,
+      }),
+    )
     const normalizedError = normalizeWsError(error, 'Initial events load failed')
     const reasonSuffix = normalizedError.reason ? ` ${normalizedError.reason}` : ''
     sendInitialError({
@@ -445,26 +494,36 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
 
   // -------- CLIENT MESSAGES (pagination) --------
   ws.on('message', async data => {
-    console.log(`[${new Date().toISOString()}]: Received WS message:`, data.toString())
     if (closed) return
+    const rawMessage = data.toString()
 
     let msg: any
     try {
-      msg = JSON.parse(String(data))
-    } catch {
-      console.warn(`[${new Date().toISOString()}]: Invalid JSON from client`)
+      msg = JSON.parse(rawMessage)
+      console.log(`[${new Date().toISOString()}]: Received WS message:`, formatWsLogInput(rawMessage, { message: msg }))
+    } catch (error) {
+      console.warn(
+        `[${new Date().toISOString()}]: Invalid JSON from client`,
+        sanitizeWsLogPayload({
+          ...getWsRawMessageMetadata(rawMessage),
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      )
       return
     }
 
     if (msg?.type === 'SCROLL') {
-      console.log(`[${new Date().toISOString()}]: Client requested SCROLL:`, msg)
+      console.log(`[${new Date().toISOString()}]: Client requested SCROLL:`, sanitizeWsLogPayload(msg))
       const limit = typeof msg.limit === 'number' && msg.limit > 0 ? Math.trunc(msg.limit) : undefined
       const token = typeof msg.continue === 'string' ? msg.continue : undefined
       if (!token) return
 
       try {
         const page = await listPage({ limit, _continue: token, captureRV: false })
-        console.log(`[${new Date().toISOString()}]: Sending PAGE to client:`, { count: page.items.length })
+        console.log(
+          `[${new Date().toISOString()}]: Sending PAGE to client:`,
+          sanitizeWsLogPayload({ count: page.items.length }),
+        )
         if (ws.readyState === WebSocket.OPEN) {
           ws.send(
             JSON.stringify({
@@ -476,11 +535,14 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
           )
         }
       } catch (error) {
-        console.error(`[${new Date().toISOString()}]: Page fetch failed:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error,
-        })
+        console.error(
+          `[${new Date().toISOString()}]: Page fetch failed:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error,
+          }),
+        )
         if (ws.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: 'PAGE_ERROR', error: 'Failed to load next page' }))
         }
@@ -507,11 +569,14 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
       console.log(`[${new Date().toISOString()}]: Sending ping to client`)
       ;(ws as any).ping?.()
     } catch (error) {
-      console.error(`[${new Date().toISOString()}]: Ping error (ignored):`, {
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-        error,
-      })
+      console.error(
+        `[${new Date().toISOString()}]: Ping error (ignored):`,
+        sanitizeWsLogPayload({
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+          error,
+        }),
+      )
     }
   }, 25_000)
 
@@ -534,16 +599,26 @@ export const eventsWebSocket: WebsocketRequestHandler = async (ws: WebSocket, re
     cleanup()
   })
   ;(ws as any).on?.('error', err => {
-    console.error(`[${new Date().toISOString()}]: WebSocket error:`, err)
+    console.error(
+      `[${new Date().toISOString()}]: WebSocket error:`,
+      sanitizeWsLogPayload({
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+        error: err,
+      }),
+    )
     cleanup()
     try {
       ;(ws as any).close?.()
     } catch (error) {
-      console.error(`[${new Date().toISOString()}]: Error closing WS after error (ignored):`, {
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-        error,
-      })
+      console.error(
+        `[${new Date().toISOString()}]: Error closing WS after error (ignored):`,
+        sanitizeWsLogPayload({
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+          error,
+        }),
+      )
     }
   })
 }

--- a/src/endpoints/listThenWatch/listWatchWebSocket.ts
+++ b/src/endpoints/listThenWatch/listWatchWebSocket.ts
@@ -12,6 +12,7 @@ import { WebsocketRequestHandler } from 'express-ws'
 import { DEVELOPMENT } from 'src/constants/envs'
 import { userKubeApi } from 'src/constants/httpAgent'
 import { filterHeadersFromEnv } from 'src/utils/filterHeadersFromEnv'
+import { formatWsLogInput, getWsRawMessageMetadata, sanitizeWsLogPayload } from 'src/utils/wsLogSanitizer'
 import { normalizeWsError } from './utils/normalizeWsError'
 
 /** Kubernetes watch phases we care about (including BOOKMARKs for RV advancement). */
@@ -90,9 +91,12 @@ const safeDecode = (s?: string) => {
  * It rotates watches periodically and on failures, handling 410 by re-listing.
  */
 export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket, req: Request) => {
-  console.log(`[${new Date().toISOString()}]: Incoming WebSocket connection (list-then-watch)`, {
-    url: req.url,
-  })
+  console.log(
+    `[${new Date().toISOString()}]: Incoming WebSocket connection (list-then-watch)`,
+    sanitizeWsLogPayload({
+      url: req.url,
+    }),
+  )
 
   // --- Parse and normalize query params ---
   const reqUrl = new URL(req.url || '', `http://${req.headers.host}`)
@@ -118,16 +122,19 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
 
   const target: ApiTriple = { apiGroup: apiGroup || undefined, apiVersion: apiVersion, plural }
 
-  console.log(`[${new Date().toISOString()}]: Query params parsed:`, {
-    namespace,
-    initialLimit,
-    initialContinue,
-    apiGroup: target.apiGroup,
-    apiVersion: target.apiVersion,
-    plural: target.plural,
-    sinceRV,
-  })
-  console.log(`[${new Date().toISOString()}]: Selectors:`, { fieldSelector, labelSelector })
+  console.log(
+    `[${new Date().toISOString()}]: Query params parsed:`,
+    sanitizeWsLogPayload({
+      namespace,
+      initialLimit,
+      initialContinue,
+      apiGroup: target.apiGroup,
+      apiVersion: target.apiVersion,
+      plural: target.plural,
+      sinceRV,
+    }),
+  )
+  console.log(`[${new Date().toISOString()}]: Selectors:`, sanitizeWsLogPayload({ fieldSelector, labelSelector }))
 
   // --- Connection + watch state ---
   let closed = false
@@ -227,7 +234,10 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
     _continue?: string
     captureRV: boolean
   }) => {
-    console.log(`[${new Date().toISOString()}]: Listing page`, { limit, _continue, captureRV, lastRV })
+    console.log(
+      `[${new Date().toISOString()}]: Listing page`,
+      sanitizeWsLogPayload({ limit, _continue, captureRV, lastRV }),
+    )
 
     // Refresh filtered headers each call in case env-driven filters change per-request.
     const filteredHeaders = filterHeadersFromEnv(req)
@@ -261,11 +271,14 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
     })
 
     const meta = body.metadata || {}
-    console.log(`[${new Date().toISOString()}]: List page received`, {
-      itemCount: items.length,
-      continue: meta._continue,
-      resourceVersion: meta.resourceVersion,
-    })
+    console.log(
+      `[${new Date().toISOString()}]: List page received`,
+      sanitizeWsLogPayload({
+        itemCount: items.length,
+        continue: meta._continue,
+        resourceVersion: meta.resourceVersion,
+      }),
+    )
 
     if (captureRV) lastRV = meta.resourceVersion
     return {
@@ -304,11 +317,14 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
           ws.send(JSON.stringify({ type: p, item: obj }))
         }
       } catch (error) {
-        console.warn(`[${new Date().toISOString()}]: Failed to send signal:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error: error,
-        })
+        console.warn(
+          `[${new Date().toISOString()}]: Failed to send signal:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error: error,
+          }),
+        )
       }
     }
   }
@@ -317,7 +333,14 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
    * k8s watch error callback. If 410 Gone, attempts to re-list to refresh RV; then restarts watch.
    */
   const onError = async (err: unknown) => {
-    console.error(`[${new Date().toISOString()}]: Watch error:`, err)
+    console.error(
+      `[${new Date().toISOString()}]: Watch error:`,
+      sanitizeWsLogPayload({
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+        error: err,
+      }),
+    )
     if (closed) return
     if (isGone410(err)) {
       console.warn(`[${new Date().toISOString()}]: 410 Gone detected, resetting list page`)
@@ -325,11 +348,14 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
         await listPage({ limit: initialLimit, _continue: undefined, captureRV: true })
       } catch (error) {
         sendServerLog('error', `[${new Date().toISOString()}]: Failed to reset listPage after 410`)
-        console.error(`[${new Date().toISOString()}]: Failed to reset listPage after 410:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error: error,
-        })
+        console.error(
+          `[${new Date().toISOString()}]: Failed to reset listPage after 410:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error: error,
+          }),
+        )
       }
     }
     // Debounced restart to avoid tight loops.
@@ -411,16 +437,26 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
               onEvent(phase, obj)
             }
           } catch (error) {
-            console.warn(`[${new Date().toISOString()}]: Failed to parse watch event line`, {
-              message: error instanceof Error ? error.message : String(error),
-              line,
-            })
+            console.warn(
+              `[${new Date().toISOString()}]: Failed to parse watch event line`,
+              sanitizeWsLogPayload({
+                message: error instanceof Error ? error.message : String(error),
+                line,
+              }),
+            )
           }
         }
       }
 
       const onStreamError = (error: unknown) => {
-        console.error(`[${new Date().toISOString()}]: Watch stream error:`, error)
+        console.error(
+          `[${new Date().toISOString()}]: Watch stream error:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error,
+          }),
+        )
         void onError(error)
       }
 
@@ -453,12 +489,15 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
         .filter(Boolean)
         .join(' | ')
       sendServerLog('error', watchDetails)
-      console.error(`[${new Date().toISOString()}]: Error starting watch:`, {
-        normalizedError,
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-        error: error,
-      })
+      console.error(
+        `[${new Date().toISOString()}]: Error starting watch:`,
+        sanitizeWsLogPayload({
+          normalizedError,
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+          error: error,
+        }),
+      )
       // If the failure is due to expired RV, re-list to refresh RV and retry.
       if (!closed && isGone410(error)) {
         console.warn(`[${new Date().toISOString()}]: Re-listing after 410 on watch start`)
@@ -466,11 +505,14 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
           await listPage({ limit: initialLimit, _continue: undefined, captureRV: true })
         } catch (error) {
           sendServerLog('error', `[${new Date().toISOString()}]: Failed re-list after 410`)
-          console.error(`[${new Date().toISOString()}]: Failed re-list after 410:`, {
-            message: error instanceof Error ? error.message : String(error),
-            stack: error instanceof Error ? error.stack : undefined,
-            error: error,
-          })
+          console.error(
+            `[${new Date().toISOString()}]: Failed re-list after 410:`,
+            sanitizeWsLogPayload({
+              message: error instanceof Error ? error.message : String(error),
+              stack: error instanceof Error ? error.stack : undefined,
+              error: error,
+            }),
+          )
         }
       }
       // Mild backoff to avoid thrashing.
@@ -507,11 +549,14 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
       } catch (error) {
         sendInitialError({ message: `[${new Date().toISOString()}]: Failed to send INITIAL page` })
         sendServerLog('error', `[${new Date().toISOString()}]: Failed to send INITIAL page`)
-        console.error(`[${new Date().toISOString()}]: Failed to send INITIAL page:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error: error,
-        })
+        console.error(
+          `[${new Date().toISOString()}]: Failed to send INITIAL page:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error: error,
+          }),
+        )
       }
     }
   } catch (error) {
@@ -531,12 +576,15 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
       reason: normalizedError.reason,
     })
     sendServerLog('error', details)
-    console.error(`[${new Date().toISOString()}]: Initial list failed:`, {
-      normalizedError,
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-      error: error,
-    })
+    console.error(
+      `[${new Date().toISOString()}]: Initial list failed:`,
+      sanitizeWsLogPayload({
+        normalizedError,
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        error: error,
+      }),
+    )
     sentInitial = true
   }
 
@@ -553,26 +601,36 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
   // -------- CLIENT MESSAGES (pagination requests) --------
 
   ws.on('message', async data => {
-    console.log(`[${new Date().toISOString()}]: Received WS message:`, data.toString())
     if (closed) return
+    const rawMessage = data.toString()
     let msg: any
     try {
-      msg = JSON.parse(String(data))
-    } catch {
-      console.warn(`[${new Date().toISOString()}]: Invalid JSON from client`)
+      msg = JSON.parse(rawMessage)
+      console.log(`[${new Date().toISOString()}]: Received WS message:`, formatWsLogInput(rawMessage, { message: msg }))
+    } catch (error) {
+      console.warn(
+        `[${new Date().toISOString()}]: Invalid JSON from client`,
+        sanitizeWsLogPayload({
+          ...getWsRawMessageMetadata(rawMessage),
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      )
       return
     }
 
     // Client asks to fetch the next page from the Kubernetes list API.
     if (msg?.type === 'SCROLL') {
-      console.log(`[${new Date().toISOString()}]: Client requested SCROLL:`, msg)
+      console.log(`[${new Date().toISOString()}]: Client requested SCROLL:`, sanitizeWsLogPayload(msg))
       const limit = typeof msg.limit === 'number' && msg.limit > 0 ? Math.trunc(msg.limit) : undefined
       const token = typeof msg.continue === 'string' ? msg.continue : undefined
       if (!token) return
 
       try {
         const page = await listPage({ limit, _continue: token, captureRV: false })
-        console.log(`[${new Date().toISOString()}]: Sending PAGE to client:`, { count: page.items.length })
+        console.log(
+          `[${new Date().toISOString()}]: Sending PAGE to client:`,
+          sanitizeWsLogPayload({ count: page.items.length }),
+        )
         if (ws.readyState === WebSocket.OPEN) {
           ws.send(
             JSON.stringify({
@@ -585,11 +643,14 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
         }
       } catch (error) {
         sendServerLog('error', `[${new Date().toISOString()}]: Page fetch failed`)
-        console.error(`[${new Date().toISOString()}]: Page fetch failed:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error: error,
-        })
+        console.error(
+          `[${new Date().toISOString()}]: Page fetch failed:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error: error,
+          }),
+        )
         if (ws.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: 'PAGE_ERROR', error: 'Failed to load next page' }))
         }
@@ -619,11 +680,14 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
       console.log(`[${new Date().toISOString()}]: Sending ping to client`)
       ;(ws as any).ping?.()
     } catch (error) {
-      console.error(`[${new Date().toISOString()}]: Ping error (ignored):`, {
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-        error: error,
-      })
+      console.error(
+        `[${new Date().toISOString()}]: Ping error (ignored):`,
+        sanitizeWsLogPayload({
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+          error: error,
+        }),
+      )
     }
   }, 25_000)
 
@@ -650,16 +714,26 @@ export const listWatchWebSocket: WebsocketRequestHandler = async (ws: WebSocket,
     cleanup()
   })
   ;(ws as any).on?.('error', err => {
-    console.error(`[${new Date().toISOString()}]: WebSocket error:`, err)
+    console.error(
+      `[${new Date().toISOString()}]: WebSocket error:`,
+      sanitizeWsLogPayload({
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+        error: err,
+      }),
+    )
     cleanup()
     try {
       ;(ws as any).close?.()
     } catch (error) {
-      console.error(`[${new Date().toISOString()}]: Error closing WS after error (ignored):`, {
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-        error: error,
-      })
+      console.error(
+        `[${new Date().toISOString()}]: Error closing WS after error (ignored):`,
+        sanitizeWsLogPayload({
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+          error: error,
+        }),
+      )
     }
   })
 }

--- a/src/endpoints/terminal/podLogs/podLogs.ts
+++ b/src/endpoints/terminal/podLogs/podLogs.ts
@@ -3,6 +3,7 @@ import { WebsocketRequestHandler } from 'express-ws'
 import { DEVELOPMENT } from 'src/constants/envs'
 import { httpsAgent, baseUrl } from 'src/constants/httpAgent'
 import { filterHeadersFromEnv } from 'src/utils/filterHeadersFromEnv'
+import { formatWsLogInput, getWsRawMessageMetadata, sanitizeWsLogPayload } from 'src/utils/wsLogSanitizer'
 
 export type TMessage = {
   type: string
@@ -43,9 +44,10 @@ export const podLogsWebSocket: WebsocketRequestHandler = async (ws, req) => {
       }`
 
       console.log(
-        `[${new Date().toISOString()}]: WebsocketPod: Connecting with user headers ${JSON.stringify(
-          DEVELOPMENT ? {} : filteredHeaders,
-        )}`,
+        `[${new Date().toISOString()}]: WebsocketPod: Connecting with user headers`,
+        formatWsLogInput(DEVELOPMENT ? '{}' : JSON.stringify(filteredHeaders), {
+          headers: DEVELOPMENT ? {} : filteredHeaders,
+        }),
       )
 
       let stop = false
@@ -79,7 +81,14 @@ export const podLogsWebSocket: WebsocketRequestHandler = async (ws, req) => {
       })
 
       podWs.on('error', error => {
-        console.error(`[${new Date().toISOString()}]: WebsocketPod: Pod WebSocket error:`, error)
+        console.error(
+          `[${new Date().toISOString()}]: WebsocketPod: Pod WebSocket error:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error,
+          }),
+        )
       })
 
       ws.on('message', message => {
@@ -113,25 +122,36 @@ export const podLogsWebSocket: WebsocketRequestHandler = async (ws, req) => {
     }
 
     ws.once('message', (message: Buffer) => {
+      const rawMessage = message.toString()
       try {
-        console.log(`[${new Date().toISOString()}]: WebSocket: Init message:`, message.toString())
-        const parsedMessage = JSON.parse(message.toString()) as TMessage
+        const parsedMessage = JSON.parse(rawMessage) as TMessage
+        console.log(
+          `[${new Date().toISOString()}]: WebSocket: Init message:`,
+          formatWsLogInput(rawMessage, { message: parsedMessage }),
+        )
         handleInit(parsedMessage)
       } catch (error) {
-        console.error(`[${new Date().toISOString()}]: WebSocket: Invalid init message:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error: error,
-        })
+        console.error(
+          `[${new Date().toISOString()}]: WebSocket: Invalid init message:`,
+          sanitizeWsLogPayload({
+            ...getWsRawMessageMetadata(rawMessage),
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error: error,
+          }),
+        )
         ws.close()
       }
     })
   } catch (error) {
-    console.error(`[${new Date().toISOString()}]: WebSocket: Error catched:`, {
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-      error: error,
-      body: req.body,
-    })
+    console.error(
+      `[${new Date().toISOString()}]: WebSocket: Error catched:`,
+      sanitizeWsLogPayload({
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        error: error,
+        body: req.body,
+      }),
+    )
   }
 }

--- a/src/endpoints/terminal/podLogs/podLogsNonWs.test.ts
+++ b/src/endpoints/terminal/podLogs/podLogsNonWs.test.ts
@@ -1,0 +1,62 @@
+jest.mock('src/constants/envs', () => ({
+  DEVELOPMENT: false,
+  WS_LOG_BLACKLIST_PATHS: ['error.config.headers.authorization'],
+  WS_LOG_WHITELIST_PATHS: [],
+  WS_LOG_PATH_FILTERS_ENABLED: true,
+}))
+
+jest.mock('src/constants/httpAgent', () => ({
+  baseUrl: 'https://cluster.local',
+  userKubeApi: {
+    get: jest.fn(),
+  },
+}))
+
+import { userKubeApi } from 'src/constants/httpAgent'
+import { startLogPolling } from './podLogsNonWs'
+
+const mockedGet = userKubeApi.get as jest.Mock
+
+describe('startLogPolling', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    mockedGet.mockReset()
+  })
+
+  test('drops authorization from logged WS error payloads when blacklist is configured', async () => {
+    const error = new Error('boom') as Error & {
+      config: { headers: Record<string, string> }
+    }
+    error.config = {
+      headers: {
+        authorization: 'Bearer secret',
+        'x-request-id': 'req-1',
+      },
+    }
+
+    mockedGet.mockRejectedValueOnce(error)
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await new Promise<void>(resolve => {
+      let polling: { stop: () => void }
+      polling = startLogPolling(
+        {
+          url: '/api/v1/namespaces/default/pods/example/log',
+          headers: {},
+        },
+        () => {},
+        () => {
+          polling.stop()
+          resolve()
+        },
+      )
+    })
+
+    const loggedPayload = consoleErrorSpy.mock.calls.find(call => call[0] === 'Error fetching logs:')?.[1] as {
+      error: { config: { headers: Record<string, string | undefined> } }
+    }
+
+    expect(loggedPayload.error.config.headers.authorization).toBeUndefined()
+    expect(loggedPayload.error.config.headers['x-request-id']).toBe('req-1')
+  })
+})

--- a/src/endpoints/terminal/podLogs/podLogsNonWs.ts
+++ b/src/endpoints/terminal/podLogs/podLogsNonWs.ts
@@ -4,6 +4,7 @@ import { WebsocketRequestHandler } from 'express-ws'
 import { DEVELOPMENT } from 'src/constants/envs'
 import { baseUrl, userKubeApi } from 'src/constants/httpAgent'
 import { filterHeadersFromEnv } from 'src/utils/filterHeadersFromEnv'
+import { formatWsLogInput, getWsRawMessageMetadata, sanitizeWsLogPayload } from 'src/utils/wsLogSanitizer'
 
 export type TMessage = {
   type: string
@@ -23,7 +24,10 @@ export const startLogPolling = (
   let prevLatestTimestamp: Date | null = null
   let latestTimestamp: Date | null = null
 
-  console.log(`[${new Date().toISOString()}]: Websocket: Using headers to fetch ${JSON.stringify(headers)}`)
+  console.log(
+    `[${new Date().toISOString()}]: Websocket: Using headers to fetch`,
+    formatWsLogInput(JSON.stringify(headers), { headers }),
+  )
   const doFetch = async () => {
     try {
       const {
@@ -82,11 +86,14 @@ export const startLogPolling = (
         error?.response?.data ||
         (error instanceof Error ? error.message : String(error))
 
-      console.error('Error fetching logs:', {
-        message: errorMessage,
-        stack: error instanceof Error ? error.stack : undefined,
-        error: error,
-      })
+      console.error(
+        'Error fetching logs:',
+        sanitizeWsLogPayload({
+          message: errorMessage,
+          stack: error instanceof Error ? error.stack : undefined,
+          error: error,
+        }),
+      )
 
       if (onError) {
         onError(typeof errorMessage === 'string' ? errorMessage : JSON.stringify(errorMessage))
@@ -116,7 +123,10 @@ export const podLogsNonWsWebSocket: WebsocketRequestHandler = async (ws, req) =>
 
   const filteredHeaders = filterHeadersFromEnv(req)
 
-  console.log(`[${new Date().toISOString()}]: Websocket: Filtered Headers: ${JSON.stringify(filteredHeaders)}`)
+  console.log(
+    `[${new Date().toISOString()}]: Websocket: Filtered Headers:`,
+    formatWsLogInput(JSON.stringify(filteredHeaders), { headers: filteredHeaders }),
+  )
 
   try {
     const handleInit = async (message: TMessage) => {
@@ -214,24 +224,35 @@ export const podLogsNonWsWebSocket: WebsocketRequestHandler = async (ws, req) =>
     }
 
     ws.once('message', (message: Buffer) => {
+      const rawMessage = message.toString()
       try {
-        console.log(`[${new Date().toISOString()}]: WebSocket: Init message:`, message.toString())
-        const parsedMessage = JSON.parse(message.toString()) as TMessage
+        const parsedMessage = JSON.parse(rawMessage) as TMessage
+        console.log(
+          `[${new Date().toISOString()}]: WebSocket: Init message:`,
+          formatWsLogInput(rawMessage, { message: parsedMessage }),
+        )
         handleInit(parsedMessage)
       } catch (error) {
-        console.error(`[${new Date().toISOString()}]: WebSocket: Invalid init message:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error: error,
-        })
+        console.error(
+          `[${new Date().toISOString()}]: WebSocket: Invalid init message:`,
+          sanitizeWsLogPayload({
+            ...getWsRawMessageMetadata(rawMessage),
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error: error,
+          }),
+        )
         ws.close()
       }
     })
   } catch (error) {
-    console.error(`[${new Date().toISOString()}]: WebSocket: Error catched:`, {
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-      error: error,
-    })
+    console.error(
+      `[${new Date().toISOString()}]: WebSocket: Error catched:`,
+      sanitizeWsLogPayload({
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        error: error,
+      }),
+    )
   }
 }

--- a/src/endpoints/terminal/terminalNode/terminalNode.ts
+++ b/src/endpoints/terminal/terminalNode/terminalNode.ts
@@ -3,6 +3,7 @@ import { WebsocketRequestHandler } from 'express-ws'
 import { DEVELOPMENT } from 'src/constants/envs'
 import { userKubeApi } from 'src/constants/httpAgent'
 import { filterHeadersFromEnv } from 'src/utils/filterHeadersFromEnv'
+import { formatWsLogInput, getWsRawMessageMetadata, sanitizeWsLogPayload } from 'src/utils/wsLogSanitizer'
 import { generateRandomLetters, getNamespaceBody, getPodFromPodTemplate, waitForPodRunning } from './utils'
 import { SHUTDOWN_MESSAGES, WARMUP_MESSAGES } from './constants'
 import { TPodTemplate, TMessage } from './types'
@@ -256,29 +257,47 @@ export const terminalNodeWebSocket: WebsocketRequestHandler = async (ws, req) =>
       })
 
       ws.on('error', error => {
-        console.error(`[${new Date().toISOString()}]: Websocket: WebSocket error:`, error)
+        console.error(
+          `[${new Date().toISOString()}]: Websocket: WebSocket error:`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error,
+          }),
+        )
       })
     }
 
     ws.once('message', (message: Buffer) => {
+      const rawMessage = message.toString()
       try {
-        console.log(`[${new Date().toISOString()}]: WebSocket: Init message:`, message.toString())
-        const parsedMessage = JSON.parse(message.toString()) as TMessage
+        const parsedMessage = JSON.parse(rawMessage) as TMessage
+        console.log(
+          `[${new Date().toISOString()}]: WebSocket: Init message:`,
+          formatWsLogInput(rawMessage, { message: parsedMessage }),
+        )
         handleInit(parsedMessage)
       } catch (error) {
-        console.error(`[${new Date().toISOString()}]: WebSocket: Invalid init message:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error: error,
-        })
+        console.error(
+          `[${new Date().toISOString()}]: WebSocket: Invalid init message:`,
+          sanitizeWsLogPayload({
+            ...getWsRawMessageMetadata(rawMessage),
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error: error,
+          }),
+        )
         ws.close()
       }
     })
   } catch (error) {
-    console.error(`[${new Date().toISOString()}]: WebSocket: Error catched`, {
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-      error: error,
-    })
+    console.error(
+      `[${new Date().toISOString()}]: WebSocket: Error catched`,
+      sanitizeWsLogPayload({
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        error: error,
+      }),
+    )
   }
 }

--- a/src/endpoints/terminal/terminalPod/terminalPod.ts
+++ b/src/endpoints/terminal/terminalPod/terminalPod.ts
@@ -3,6 +3,7 @@ import { WebsocketRequestHandler } from 'express-ws'
 import { DEVELOPMENT } from 'src/constants/envs'
 import { httpsAgent, baseUrl } from 'src/constants/httpAgent'
 import { filterHeadersFromEnv } from 'src/utils/filterHeadersFromEnv'
+import { formatWsLogInput, getWsRawMessageMetadata, sanitizeWsLogPayload } from 'src/utils/wsLogSanitizer'
 
 export type TMessage = {
   type: string
@@ -47,9 +48,10 @@ export const terminalPodWebSocket: WebsocketRequestHandler = async (ws, req) => 
       ].join('')
 
       console.log(
-        `[${new Date().toISOString()}]: WebsocketPod: Connecting with user headers ${JSON.stringify(
-          DEVELOPMENT ? {} : filteredHeaders,
-        )}`,
+        `[${new Date().toISOString()}]: WebsocketPod: Connecting with user headers`,
+        formatWsLogInput(DEVELOPMENT ? '{}' : JSON.stringify(filteredHeaders), {
+          headers: DEVELOPMENT ? {} : filteredHeaders,
+        }),
       )
       try {
         const podWs = new WebSocket(execUrl, {
@@ -76,7 +78,14 @@ export const terminalPodWebSocket: WebsocketRequestHandler = async (ws, req) => 
         })
 
         podWs.on('error', error => {
-          console.error(`[${new Date().toISOString()}]: WebsocketPod: Pod WebSocket error:`, error)
+          console.error(
+            `[${new Date().toISOString()}]: WebsocketPod: Pod WebSocket error:`,
+            sanitizeWsLogPayload({
+              message: error instanceof Error ? error.message : String(error),
+              stack: error instanceof Error ? error.stack : undefined,
+              error,
+            }),
+          )
           const errorMessage = error instanceof Error ? error.message : String(error)
           sendError(ws, `Failed to connect to container: ${errorMessage}`)
         })
@@ -93,11 +102,14 @@ export const terminalPodWebSocket: WebsocketRequestHandler = async (ws, req) => 
           podWs.close()
         })
       } catch (error) {
-        console.error(`[${new Date().toISOString()}]: WebSocket: Error catched`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error: error,
-        })
+        console.error(
+          `[${new Date().toISOString()}]: WebSocket: Error catched`,
+          sanitizeWsLogPayload({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error: error,
+          }),
+        )
         const errorMessage = error instanceof Error ? error.message : String(error)
         sendError(ws, `Connection error: ${errorMessage}`)
         ws.close()
@@ -105,26 +117,37 @@ export const terminalPodWebSocket: WebsocketRequestHandler = async (ws, req) => 
     }
 
     ws.once('message', (message: Buffer) => {
+      const rawMessage = message.toString()
       try {
-        console.log(`[${new Date().toISOString()}]: WebSocket: Init message:`, message.toString())
-        const parsedMessage = JSON.parse(message.toString()) as TMessage
+        const parsedMessage = JSON.parse(rawMessage) as TMessage
+        console.log(
+          `[${new Date().toISOString()}]: WebSocket: Init message:`,
+          formatWsLogInput(rawMessage, { message: parsedMessage }),
+        )
         handleInit(parsedMessage)
       } catch (error) {
-        console.error(`[${new Date().toISOString()}]: WebSocket: Invalid init message:`, {
-          message: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          error: error,
-        })
+        console.error(
+          `[${new Date().toISOString()}]: WebSocket: Invalid init message:`,
+          sanitizeWsLogPayload({
+            ...getWsRawMessageMetadata(rawMessage),
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            error: error,
+          }),
+        )
         sendError(ws, 'Invalid message format')
         ws.close()
       }
     })
   } catch (error) {
-    console.error(`[${new Date().toISOString()}]: WebSocket: Error catched`, {
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-      error: error,
-    })
+    console.error(
+      `[${new Date().toISOString()}]: WebSocket: Error catched`,
+      sanitizeWsLogPayload({
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        error: error,
+      }),
+    )
     const errorMessage = error instanceof Error ? error.message : String(error)
     sendError(ws, `Internal error: ${errorMessage}`)
     ws.close()

--- a/src/utils/parseJsonEnvStringArray.ts
+++ b/src/utils/parseJsonEnvStringArray.ts
@@ -1,0 +1,21 @@
+export const parseJsonEnvStringArray = (value: string | undefined, envName: string): string[] => {
+  if (!value || value.trim().length === 0) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(value)
+
+    if (!Array.isArray(parsed)) {
+      console.warn(`[envs]: ${envName} must be a JSON array of strings`)
+      return []
+    }
+
+    return parsed.map(item => (typeof item === 'string' ? item.trim() : '')).filter(Boolean)
+  } catch (error) {
+    console.warn(`[envs]: Failed to parse ${envName}; expected a JSON array of strings`, {
+      message: error instanceof Error ? error.message : String(error),
+    })
+    return []
+  }
+}

--- a/src/utils/wsLogSanitizer.test.ts
+++ b/src/utils/wsLogSanitizer.test.ts
@@ -130,4 +130,197 @@ describe('sanitizeWsLogPayload', () => {
       headers: {},
     })
   })
+
+  describe('** globstar wildcard', () => {
+    test('**.authorization blacklist strips authorization at any depth', () => {
+      expect(
+        sanitizeWsLogPayload(payload, {
+          blacklistPaths: ['**.authorization'],
+        }),
+      ).toEqual({
+        error: {
+          message: 'boom',
+          config: {
+            headers: {
+              cookie: 'session=secret',
+              'x-request-id': 'req-1',
+            },
+            url: '/api/v1/pods',
+          },
+          response: {
+            status: 403,
+          },
+        },
+        headers: {
+          'x-real-ip': '127.0.0.1',
+        },
+      })
+    })
+
+    test('**.headers blacklist strips entire headers subtrees at any depth', () => {
+      expect(
+        sanitizeWsLogPayload(payload, {
+          blacklistPaths: ['**.headers'],
+        }),
+      ).toEqual({
+        error: {
+          message: 'boom',
+          config: {
+            url: '/api/v1/pods',
+          },
+          response: {
+            status: 403,
+          },
+        },
+      })
+    })
+
+    test('** at end of pattern strips entire subtree from that point', () => {
+      expect(
+        sanitizeWsLogPayload(payload, {
+          blacklistPaths: ['error.config.**'],
+        }),
+      ).toEqual({
+        error: {
+          message: 'boom',
+          response: {
+            status: 403,
+          },
+        },
+        headers: {
+          authorization: 'Bearer header-secret',
+          'x-real-ip': '127.0.0.1',
+        },
+      })
+    })
+
+    test('** in the middle of a pattern', () => {
+      expect(
+        sanitizeWsLogPayload(payload, {
+          blacklistPaths: ['error.**.authorization'],
+        }),
+      ).toEqual({
+        error: {
+          message: 'boom',
+          config: {
+            headers: {
+              cookie: 'session=secret',
+              'x-request-id': 'req-1',
+            },
+            url: '/api/v1/pods',
+          },
+          response: {
+            status: 403,
+          },
+        },
+        headers: {
+          authorization: 'Bearer header-secret',
+          'x-real-ip': '127.0.0.1',
+        },
+      })
+    })
+  })
+
+  describe('* single-segment wildcard', () => {
+    test('*.authorization matches one level only', () => {
+      expect(
+        sanitizeWsLogPayload(payload, {
+          blacklistPaths: ['*.authorization'],
+        }),
+      ).toEqual({
+        error: {
+          message: 'boom',
+          config: {
+            headers: {
+              authorization: 'Bearer secret',
+              cookie: 'session=secret',
+              'x-request-id': 'req-1',
+            },
+            url: '/api/v1/pods',
+          },
+          response: {
+            status: 403,
+          },
+        },
+        headers: {
+          'x-real-ip': '127.0.0.1',
+        },
+      })
+    })
+
+    test('error.*.headers matches error.config.headers but not deeper', () => {
+      expect(
+        sanitizeWsLogPayload(payload, {
+          blacklistPaths: ['error.*.headers'],
+        }),
+      ).toEqual({
+        error: {
+          message: 'boom',
+          config: {
+            url: '/api/v1/pods',
+          },
+          response: {
+            status: 403,
+          },
+        },
+        headers: {
+          authorization: 'Bearer header-secret',
+          'x-real-ip': '127.0.0.1',
+        },
+      })
+    })
+  })
+
+  describe('mixed wildcards with exact paths', () => {
+    test('combines ** wildcard with exact path', () => {
+      expect(
+        sanitizeWsLogPayload(payload, {
+          blacklistPaths: ['**.cookie', 'headers.authorization'],
+        }),
+      ).toEqual({
+        error: {
+          message: 'boom',
+          config: {
+            headers: {
+              authorization: 'Bearer secret',
+              'x-request-id': 'req-1',
+            },
+            url: '/api/v1/pods',
+          },
+          response: {
+            status: 403,
+          },
+        },
+        headers: {
+          'x-real-ip': '127.0.0.1',
+        },
+      })
+    })
+  })
+
+  describe('wildcard whitelist', () => {
+    test('**.message keeps only message fields at any depth', () => {
+      expect(
+        sanitizeWsLogPayload(payload, {
+          whitelistPaths: ['**.message'],
+        }),
+      ).toEqual({
+        error: {
+          message: 'boom',
+        },
+      })
+    })
+
+    test('*.* keeps all fields one level deep', () => {
+      expect(
+        sanitizeWsLogPayload(
+          { a: { x: 1, y: 2 }, b: { z: 3 }, c: 'flat' },
+          { whitelistPaths: ['*.*'] },
+        ),
+      ).toEqual({
+        a: { x: 1, y: 2 },
+        b: { z: 3 },
+      })
+    })
+  })
 })

--- a/src/utils/wsLogSanitizer.test.ts
+++ b/src/utils/wsLogSanitizer.test.ts
@@ -1,0 +1,133 @@
+jest.mock('src/constants/envs', () => ({
+  WS_LOG_BLACKLIST_PATHS: [],
+  WS_LOG_WHITELIST_PATHS: [],
+  WS_LOG_PATH_FILTERS_ENABLED: false,
+}))
+
+import { sanitizeWsLogPayload, formatWsLogInput } from './wsLogSanitizer'
+
+describe('sanitizeWsLogPayload', () => {
+  const payload = {
+    error: {
+      message: 'boom',
+      config: {
+        headers: {
+          authorization: 'Bearer secret',
+          cookie: 'session=secret',
+          'x-request-id': 'req-1',
+        },
+        url: '/api/v1/pods',
+      },
+      response: {
+        status: 403,
+      },
+    },
+    headers: {
+      authorization: 'Bearer header-secret',
+      'x-real-ip': '127.0.0.1',
+    },
+  }
+
+  test('returns original payload when no filters are configured', () => {
+    expect(sanitizeWsLogPayload(payload, { whitelistPaths: [], blacklistPaths: [] })).toBe(payload)
+  })
+
+  test('keeps only whitelisted paths', () => {
+    expect(
+      sanitizeWsLogPayload(payload, {
+        whitelistPaths: ['error.message', 'error.config.url'],
+      }),
+    ).toEqual({
+      error: {
+        message: 'boom',
+        config: {
+          url: '/api/v1/pods',
+        },
+      },
+    })
+  })
+
+  test('drops blacklisted subtrees by prefix', () => {
+    expect(
+      sanitizeWsLogPayload(payload, {
+        blacklistPaths: ['error.config.headers.authorization', 'headers.authorization'],
+      }),
+    ).toEqual({
+      error: {
+        message: 'boom',
+        config: {
+          headers: {
+            cookie: 'session=secret',
+            'x-request-id': 'req-1',
+          },
+          url: '/api/v1/pods',
+        },
+        response: {
+          status: 403,
+        },
+      },
+      headers: {
+        'x-real-ip': '127.0.0.1',
+      },
+    })
+  })
+
+  test('prefers whitelist over blacklist when both are configured', () => {
+    expect(
+      sanitizeWsLogPayload(payload, {
+        whitelistPaths: ['error'],
+        blacklistPaths: ['error.config.headers.authorization'],
+      }),
+    ).toEqual({
+      error: {
+        message: 'boom',
+        config: {
+          headers: {
+            authorization: 'Bearer secret',
+            cookie: 'session=secret',
+            'x-request-id': 'req-1',
+          },
+          url: '/api/v1/pods',
+        },
+        response: {
+          status: 403,
+        },
+      },
+    })
+  })
+
+  test('supports nested prefix matches', () => {
+    expect(
+      sanitizeWsLogPayload(payload, {
+        blacklistPaths: ['error.config.headers'],
+      }),
+    ).toEqual({
+      error: {
+        message: 'boom',
+        config: {
+          url: '/api/v1/pods',
+        },
+        response: {
+          status: 403,
+        },
+      },
+      headers: {
+        authorization: 'Bearer header-secret',
+        'x-real-ip': '127.0.0.1',
+      },
+    })
+  })
+
+  test('passes primitives through unchanged', () => {
+    expect(sanitizeWsLogPayload('plain text', { blacklistPaths: ['error.message'] })).toBe('plain text')
+  })
+
+  test('formats raw input only when filters are configured', () => {
+    expect(formatWsLogInput('raw', { headers: { authorization: 'secret' } }, { blacklistPaths: [] })).toBe('raw')
+    expect(
+      formatWsLogInput('raw', { headers: { authorization: 'secret' } }, { blacklistPaths: ['headers.authorization'] }),
+    ).toEqual({
+      headers: {},
+    })
+  })
+})

--- a/src/utils/wsLogSanitizer.ts
+++ b/src/utils/wsLogSanitizer.ts
@@ -1,0 +1,170 @@
+import { WS_LOG_BLACKLIST_PATHS, WS_LOG_PATH_FILTERS_ENABLED, WS_LOG_WHITELIST_PATHS } from 'src/constants/envs'
+
+type TWsLogSanitizerOptions = {
+  blacklistPaths?: string[]
+  whitelistPaths?: string[]
+}
+
+type TPathTokens = string[]
+
+const normalizePaths = (paths: string[]) =>
+  paths
+    .map(path => path.trim())
+    .filter(Boolean)
+    .map(path =>
+      path
+        .split('.')
+        .map(part => part.trim())
+        .filter(Boolean),
+    )
+    .filter(path => path.length > 0)
+
+const isObjectLike = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+const isPrefixPath = (candidatePrefix: TPathTokens, targetPath: TPathTokens): boolean =>
+  candidatePrefix.length <= targetPath.length && candidatePrefix.every((part, index) => part === targetPath[index])
+
+const hasDescendantPath = (paths: TPathTokens[], currentPath: TPathTokens): boolean =>
+  paths.some(path => isPrefixPath(currentPath, path))
+
+const hasAncestorPath = (paths: TPathTokens[], currentPath: TPathTokens): boolean =>
+  paths.some(path => isPrefixPath(path, currentPath))
+
+const cloneValue = (value: unknown, seen = new WeakMap<object, unknown>()): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(item => cloneValue(item, seen))
+  }
+
+  if (!isObjectLike(value)) {
+    return value
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime())
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return Buffer.from(value)
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]'
+  }
+
+  const result: Record<string, unknown> = {}
+  seen.set(value, result)
+
+  for (const key of Object.getOwnPropertyNames(value)) {
+    result[key] = cloneValue((value as Record<string, unknown>)[key], seen)
+  }
+
+  return result
+}
+
+const sanitizeWithWhitelist = (
+  value: unknown,
+  whitelistPaths: TPathTokens[],
+  currentPath: TPathTokens = [],
+): unknown => {
+  if (hasAncestorPath(whitelistPaths, currentPath)) {
+    return cloneValue(value)
+  }
+
+  if (!hasDescendantPath(whitelistPaths, currentPath)) {
+    return undefined
+  }
+
+  if (Array.isArray(value)) {
+    const items = value
+      .map(item => sanitizeWithWhitelist(item, whitelistPaths, currentPath))
+      .filter(item => item !== undefined)
+    return items.length > 0 ? items : undefined
+  }
+
+  if (!isObjectLike(value)) {
+    return cloneValue(value)
+  }
+
+  const result: Record<string, unknown> = {}
+
+  for (const key of Object.getOwnPropertyNames(value)) {
+    const nextPath = [...currentPath, key]
+    const sanitized = sanitizeWithWhitelist((value as Record<string, unknown>)[key], whitelistPaths, nextPath)
+    if (sanitized !== undefined) {
+      result[key] = sanitized
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+const sanitizeWithBlacklist = (
+  value: unknown,
+  blacklistPaths: TPathTokens[],
+  currentPath: TPathTokens = [],
+): unknown => {
+  if (hasAncestorPath(blacklistPaths, currentPath)) {
+    return undefined
+  }
+
+  if (!hasDescendantPath(blacklistPaths, currentPath)) {
+    return cloneValue(value)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => sanitizeWithBlacklist(item, blacklistPaths, currentPath))
+  }
+
+  if (!isObjectLike(value)) {
+    return cloneValue(value)
+  }
+
+  const result: Record<string, unknown> = {}
+
+  for (const key of Object.getOwnPropertyNames(value)) {
+    const nextPath = [...currentPath, key]
+    const sanitized = sanitizeWithBlacklist((value as Record<string, unknown>)[key], blacklistPaths, nextPath)
+    if (sanitized !== undefined) {
+      result[key] = sanitized
+    }
+  }
+
+  return result
+}
+
+const resolvePaths = (options?: TWsLogSanitizerOptions) => ({
+  blacklistPaths: normalizePaths(options?.blacklistPaths ?? WS_LOG_BLACKLIST_PATHS),
+  whitelistPaths: normalizePaths(options?.whitelistPaths ?? WS_LOG_WHITELIST_PATHS),
+})
+
+export const hasWsLogPathFilters = (options?: TWsLogSanitizerOptions): boolean => {
+  const { blacklistPaths, whitelistPaths } = resolvePaths(options)
+  return whitelistPaths.length > 0 || blacklistPaths.length > 0
+}
+
+export const sanitizeWsLogPayload = (payload: unknown, options?: TWsLogSanitizerOptions): unknown => {
+  const { blacklistPaths, whitelistPaths } = resolvePaths(options)
+
+  if (whitelistPaths.length > 0) {
+    return sanitizeWithWhitelist(payload, whitelistPaths)
+  }
+
+  if (blacklistPaths.length > 0) {
+    return sanitizeWithBlacklist(payload, blacklistPaths)
+  }
+
+  return payload
+}
+
+export const formatWsLogInput = <TRaw>(
+  rawFallback: TRaw,
+  structuredPayload: unknown,
+  options?: TWsLogSanitizerOptions,
+) => (hasWsLogPathFilters(options) ? sanitizeWsLogPayload(structuredPayload, options) : rawFallback)
+
+export const getWsRawMessageMetadata = (rawMessage: Buffer | string) => ({
+  rawMessageLength: typeof rawMessage === 'string' ? Buffer.byteLength(rawMessage, 'utf8') : rawMessage.length,
+})
+
+export { WS_LOG_PATH_FILTERS_ENABLED }
+export type { TWsLogSanitizerOptions }

--- a/src/utils/wsLogSanitizer.ts
+++ b/src/utils/wsLogSanitizer.ts
@@ -21,14 +21,63 @@ const normalizePaths = (paths: string[]) =>
 
 const isObjectLike = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
 
-const isPrefixPath = (candidatePrefix: TPathTokens, targetPath: TPathTokens): boolean =>
-  candidatePrefix.length <= targetPath.length && candidatePrefix.every((part, index) => part === targetPath[index])
+/**
+ * Does `pattern` match a prefix of `path`? i.e. pattern matches path[0..k] for some k <= path.length.
+ * Supports `*` (one segment) and `**` (zero or more segments).
+ */
+const isGlobPrefixOf = (pattern: TPathTokens, path: TPathTokens, pi = 0, si = 0): boolean => {
+  if (pi >= pattern.length) return true
+
+  const token = pattern[pi]
+
+  if (token === '**') {
+    // skip: ** matches zero segments
+    if (isGlobPrefixOf(pattern, path, pi + 1, si)) return true
+    // consume: ** eats one segment, stays active
+    if (si < path.length && isGlobPrefixOf(pattern, path, pi, si + 1)) return true
+    return false
+  }
+
+  if (si >= path.length) return false
+
+  if (token === '*' || token === path[si]) {
+    return isGlobPrefixOf(pattern, path, pi + 1, si + 1)
+  }
+
+  return false
+}
+
+/**
+ * Can `partialPath` be extended to fully match `pattern`?
+ * Supports `*` (one segment) and `**` (zero or more segments).
+ */
+const canLeadToGlobMatch = (pattern: TPathTokens, partialPath: TPathTokens, pi = 0, si = 0): boolean => {
+  if (si >= partialPath.length) return true
+
+  if (pi >= pattern.length) return false
+
+  const token = pattern[pi]
+
+  if (token === '**') {
+    // skip: ** matches zero segments
+    if (canLeadToGlobMatch(pattern, partialPath, pi + 1, si)) return true
+    // consume: ** eats one segment, stays active
+    if (canLeadToGlobMatch(pattern, partialPath, pi, si + 1)) return true
+    return false
+  }
+
+  if (token === '*' || token === partialPath[si]) {
+    return canLeadToGlobMatch(pattern, partialPath, pi + 1, si + 1)
+  }
+
+  return false
+}
 
 const hasDescendantPath = (paths: TPathTokens[], currentPath: TPathTokens): boolean =>
-  paths.some(path => isPrefixPath(currentPath, path))
+  paths.some(path => canLeadToGlobMatch(path, currentPath))
 
 const hasAncestorPath = (paths: TPathTokens[], currentPath: TPathTokens): boolean =>
-  paths.some(path => isPrefixPath(path, currentPath))
+  paths.some(path => isGlobPrefixOf(path, currentPath))
 
 const cloneValue = (value: unknown, seen = new WeakMap<object, unknown>()): unknown => {
   if (Array.isArray(value)) {
@@ -82,7 +131,7 @@ const sanitizeWithWhitelist = (
   }
 
   if (!isObjectLike(value)) {
-    return cloneValue(value)
+    return undefined
   }
 
   const result: Record<string, unknown> = {}


### PR DESCRIPTION
Add configurable WS log field filtering via WS_LOG_WHITELIST_PATHS / WS_LOG_BLACKLIST_PATHS env vars. All 6 WebSocket handlers now sanitize error log payloads through sanitizeWsLogPayload(), preventing auth tokens and cookies from leaking into server logs. If neither env is set, behavior is unchanged.