### PR TITLE
[CLOUD-124]: oneOf branching and other keywords

### DIFF
--- a/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.test.ts
+++ b/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.test.ts
@@ -197,7 +197,7 @@ describe('normalizeV3SchemaForForms', () => {
     })
   })
 
-  it('preserves pattern, string length, and numeric range validation keywords', () => {
+  it('preserves pattern, string length, array size, and numeric range validation keywords', () => {
     const result = normalizeV3SchemaForForms({
       type: 'object',
       properties: {
@@ -211,6 +211,14 @@ describe('normalizeV3SchemaForForms', () => {
           type: 'integer',
           minimum: 1,
           maximum: 65535,
+        },
+        hosts: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 10,
+          items: {
+            type: 'string',
+          },
         },
       },
     })
@@ -228,6 +236,14 @@ describe('normalizeV3SchemaForForms', () => {
           type: 'integer',
           minimum: 1,
           maximum: 65535,
+        },
+        hosts: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 10,
+          items: {
+            type: 'string',
+          },
         },
       },
     })
@@ -261,6 +277,48 @@ describe('normalizeV3SchemaForForms', () => {
           type: 'string',
           minLength: 3,
           maxLength: 20,
+        },
+      },
+    })
+  })
+
+  it('narrows minItems and maxItems across compatible allOf branches', () => {
+    const result = normalizeV3SchemaForForms({
+      type: 'object',
+      properties: {
+        hosts: {
+          allOf: [
+            {
+              type: 'array',
+              minItems: 1,
+              maxItems: 10,
+              items: {
+                type: 'string',
+              },
+            } as any,
+            {
+              type: 'array',
+              minItems: 2,
+              maxItems: 5,
+              items: {
+                type: 'string',
+              },
+            } as any,
+          ],
+        } as any,
+      },
+    })
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        hosts: {
+          type: 'array',
+          minItems: 2,
+          maxItems: 5,
+          items: {
+            type: 'string',
+          },
         },
       },
     })
@@ -861,6 +919,56 @@ describe('normalizeV3SchemaForForms', () => {
             {
               type: 'string',
               maxLength: 5,
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  it('preserves impossible array size allOf constraints so unsupported policy can still catch them', () => {
+    const result = normalizeV3SchemaForForms({
+      type: 'object',
+      properties: {
+        hosts: {
+          allOf: [
+            {
+              type: 'array',
+              minItems: 10,
+              items: {
+                type: 'string',
+              },
+            },
+            {
+              type: 'array',
+              maxItems: 5,
+              items: {
+                type: 'string',
+              },
+            },
+          ],
+        } as any,
+      },
+    })
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        hosts: {
+          allOf: [
+            {
+              type: 'array',
+              minItems: 10,
+              items: {
+                type: 'string',
+              },
+            },
+            {
+              type: 'array',
+              maxItems: 5,
+              items: {
+                type: 'string',
+              },
             },
           ],
         },

--- a/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.test.ts
+++ b/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.test.ts
@@ -197,13 +197,15 @@ describe('normalizeV3SchemaForForms', () => {
     })
   })
 
-  it('preserves pattern and numeric range validation keywords', () => {
+  it('preserves pattern, string length, and numeric range validation keywords', () => {
     const result = normalizeV3SchemaForForms({
       type: 'object',
       properties: {
         url: {
           type: 'string',
           pattern: '^https?://',
+          minLength: 8,
+          maxLength: 2048,
         },
         port: {
           type: 'integer',
@@ -219,11 +221,46 @@ describe('normalizeV3SchemaForForms', () => {
         url: {
           type: 'string',
           pattern: '^https?://',
+          minLength: 8,
+          maxLength: 2048,
         },
         port: {
           type: 'integer',
           minimum: 1,
           maximum: 65535,
+        },
+      },
+    })
+  })
+
+  it('narrows minLength and maxLength across compatible allOf branches', () => {
+    const result = normalizeV3SchemaForForms({
+      type: 'object',
+      properties: {
+        name: {
+          allOf: [
+            {
+              type: 'string',
+              minLength: 1,
+              maxLength: 63,
+            } as any,
+            {
+              type: 'string',
+              minLength: 3,
+              maxLength: 20,
+            } as any,
+          ],
+        } as any,
+      },
+    })
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          minLength: 3,
+          maxLength: 20,
         },
       },
     })
@@ -786,6 +823,44 @@ describe('normalizeV3SchemaForForms', () => {
             },
             {
               type: 'string',
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  it('preserves impossible string length allOf constraints so unsupported policy can still catch them', () => {
+    const result = normalizeV3SchemaForForms({
+      type: 'object',
+      properties: {
+        name: {
+          allOf: [
+            {
+              type: 'string',
+              minLength: 10,
+            },
+            {
+              type: 'string',
+              maxLength: 5,
+            },
+          ],
+        } as any,
+      },
+    })
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        name: {
+          allOf: [
+            {
+              type: 'string',
+              minLength: 10,
+            },
+            {
+              type: 'string',
+              maxLength: 5,
             },
           ],
         },

--- a/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.test.ts
+++ b/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.test.ts
@@ -197,6 +197,71 @@ describe('normalizeV3SchemaForForms', () => {
     })
   })
 
+  it('preserves pattern and numeric range validation keywords', () => {
+    const result = normalizeV3SchemaForForms({
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          pattern: '^https?://',
+        },
+        port: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 65535,
+        },
+      },
+    })
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          pattern: '^https?://',
+        },
+        port: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 65535,
+        },
+      },
+    })
+  })
+
+  it('narrows minimum and maximum across compatible allOf branches', () => {
+    const result = normalizeV3SchemaForForms({
+      type: 'object',
+      properties: {
+        port: {
+          allOf: [
+            {
+              type: 'integer',
+              minimum: 1,
+              maximum: 65535,
+            } as any,
+            {
+              type: 'integer',
+              minimum: 1024,
+              maximum: 8080,
+            } as any,
+          ],
+        } as any,
+      },
+    })
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        port: {
+          type: 'integer',
+          minimum: 1024,
+          maximum: 8080,
+        },
+      },
+    })
+  })
+
   it('merges compatible multi-entry allOf object schemas into a regular form node', () => {
     const result = normalizeV3SchemaForForms({
       type: 'object',

--- a/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.test.ts
+++ b/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.test.ts
@@ -389,6 +389,116 @@ describe('normalizeV3SchemaForForms', () => {
     })
   })
 
+  it('lowers oneOf branches with enum matchers and not.required into normalized branch metadata', () => {
+    const result = normalizeV3SchemaForForms({
+      type: 'object',
+      properties: {
+        spec: {
+          type: 'object',
+          required: ['type'],
+          properties: {
+            type: {
+              type: 'string',
+              enum: ['service', 'url'],
+            },
+            service: {
+              type: 'object',
+              required: ['name', 'port'],
+              properties: {
+                name: {
+                  type: 'string',
+                },
+                port: {
+                  type: 'integer',
+                  minimum: 1,
+                  maximum: 65535,
+                },
+              },
+            },
+            url: {
+              type: 'string',
+              pattern: '^https?://',
+            },
+          },
+          oneOf: [
+            {
+              required: ['service'],
+              properties: {
+                type: {
+                  enum: ['service'],
+                },
+              },
+              not: {
+                required: ['url'],
+              },
+            } as any,
+            {
+              required: ['url'],
+              properties: {
+                type: {
+                  enum: ['url'],
+                },
+              },
+              not: {
+                required: ['service'],
+              },
+            } as any,
+          ],
+        } as any,
+      },
+    })
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        spec: {
+          type: 'object',
+          required: ['type'],
+          properties: {
+            type: {
+              type: 'string',
+              enum: ['service', 'url'],
+            },
+            service: {
+              type: 'object',
+              required: ['name', 'port'],
+              properties: {
+                name: {
+                  type: 'string',
+                },
+                port: {
+                  type: 'integer',
+                  minimum: 1,
+                  maximum: 65535,
+                },
+              },
+            },
+            url: {
+              type: 'string',
+              pattern: '^https?://',
+            },
+          },
+          oneOfBranches: [
+            {
+              required: ['service'],
+              match: {
+                type: 'service',
+              },
+              forbidden: ['url'],
+            },
+            {
+              required: ['url'],
+              match: {
+                type: 'url',
+              },
+              forbidden: ['service'],
+            },
+          ],
+        },
+      },
+    })
+  })
+
   it('keeps unsupported oneOf branches untouched so policy can still catch them', () => {
     const result = normalizeV3SchemaForForms({
       type: 'object',
@@ -431,6 +541,100 @@ describe('normalizeV3SchemaForForms', () => {
                 shell: {
                   minLength: 1,
                 },
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  it('keeps oneOf branches with unsupported not untouched so policy can still catch them', () => {
+    const result = normalizeV3SchemaForForms({
+      type: 'object',
+      properties: {
+        spec: {
+          type: 'object',
+          required: ['type'],
+          properties: {
+            type: {
+              type: 'string',
+              enum: ['service', 'url'],
+            },
+            service: { type: 'object' },
+            url: { type: 'string' },
+          },
+          oneOf: [
+            {
+              required: ['service'],
+              properties: {
+                type: {
+                  enum: ['service'],
+                },
+              },
+              not: {
+                properties: {
+                  url: {
+                    type: 'string',
+                  },
+                },
+              },
+            } as any,
+            {
+              required: ['url'],
+              properties: {
+                type: {
+                  enum: ['url'],
+                },
+              },
+              not: {
+                required: ['service'],
+              },
+            } as any,
+          ],
+        } as any,
+      },
+    })
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        spec: {
+          type: 'object',
+          required: ['type'],
+          properties: {
+            type: {
+              type: 'string',
+              enum: ['service', 'url'],
+            },
+            service: { type: 'object' },
+            url: { type: 'string' },
+          },
+          oneOf: [
+            {
+              required: ['service'],
+              properties: {
+                type: {
+                  enum: ['service'],
+                },
+              },
+              not: {
+                properties: {
+                  url: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+            {
+              required: ['url'],
+              properties: {
+                type: {
+                  enum: ['url'],
+                },
+              },
+              not: {
+                required: ['service'],
               },
             },
           ],

--- a/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.test.ts
+++ b/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.test.ts
@@ -197,18 +197,20 @@ describe('normalizeV3SchemaForForms', () => {
     })
   })
 
-  it('preserves pattern, string length, array size, and numeric range validation keywords', () => {
+  it('preserves format, pattern, string length, array size, and numeric range validation keywords', () => {
     const result = normalizeV3SchemaForForms({
       type: 'object',
       properties: {
         url: {
           type: 'string',
+          format: 'uri',
           pattern: '^https?://',
           minLength: 8,
           maxLength: 2048,
         },
         port: {
           type: 'integer',
+          format: 'int32',
           minimum: 1,
           maximum: 65535,
         },
@@ -228,12 +230,14 @@ describe('normalizeV3SchemaForForms', () => {
       properties: {
         url: {
           type: 'string',
+          format: 'uri',
           pattern: '^https?://',
           minLength: 8,
           maxLength: 2048,
         },
         port: {
           type: 'integer',
+          format: 'int32',
           minimum: 1,
           maximum: 65535,
         },
@@ -244,6 +248,38 @@ describe('normalizeV3SchemaForForms', () => {
           items: {
             type: 'string',
           },
+        },
+      },
+    })
+  })
+
+  it('preserves matching format across compatible allOf branches', () => {
+    const result = normalizeV3SchemaForForms({
+      type: 'object',
+      properties: {
+        createdAt: {
+          allOf: [
+            {
+              type: 'string',
+              format: 'date-time',
+            } as any,
+            {
+              type: 'string',
+              format: 'date-time',
+              minLength: 20,
+            } as any,
+          ],
+        } as any,
+      },
+    })
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        createdAt: {
+          type: 'string',
+          format: 'date-time',
+          minLength: 20,
         },
       },
     })
@@ -828,7 +864,7 @@ describe('normalizeV3SchemaForForms', () => {
       properties: {
         spec: {
           type: 'string',
-          format: 'date-time',
+          contentEncoding: 'base64',
         } as any,
       },
     })
@@ -836,7 +872,7 @@ describe('normalizeV3SchemaForForms', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       '[openapi-v3-normalize]: unknown schema keyword(s) encountered during form normalization',
       {
-        unknownKeys: ['format'],
+        unknownKeys: ['contentEncoding'],
       },
     )
 
@@ -881,6 +917,44 @@ describe('normalizeV3SchemaForForms', () => {
             },
             {
               type: 'string',
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  it('preserves conflicting format allOf constraints so unsupported policy can still catch them', () => {
+    const result = normalizeV3SchemaForForms({
+      type: 'object',
+      properties: {
+        timestamp: {
+          allOf: [
+            {
+              type: 'string',
+              format: 'date',
+            },
+            {
+              type: 'string',
+              format: 'date-time',
+            },
+          ],
+        } as any,
+      },
+    })
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        timestamp: {
+          allOf: [
+            {
+              type: 'string',
+              format: 'date',
+            },
+            {
+              type: 'string',
+              format: 'date-time',
             },
           ],
         },

--- a/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.ts
+++ b/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.ts
@@ -31,6 +31,8 @@ const knownSchemaNodeKeys = new Set([
   'pattern',
   'minLength',
   'maxLength',
+  'minItems',
+  'maxItems',
   'minimum',
   'maximum',
   'description',
@@ -101,6 +103,20 @@ const mergeMinLength = (base?: number, overlay?: number): number | undefined => 
 }
 
 const mergeMaxLength = (base?: number, overlay?: number): number | undefined => {
+  if (base === undefined) return overlay
+  if (overlay === undefined) return base
+
+  return Math.min(base, overlay)
+}
+
+const mergeMinItems = (base?: number, overlay?: number): number | undefined => {
+  if (base === undefined) return overlay
+  if (overlay === undefined) return base
+
+  return Math.max(base, overlay)
+}
+
+const mergeMaxItems = (base?: number, overlay?: number): number | undefined => {
   if (base === undefined) return overlay
   if (overlay === undefined) return base
 
@@ -251,6 +267,8 @@ const mergeSchemaNodes = (
     pattern: basePattern,
     minLength: baseMinLength,
     maxLength: baseMaxLength,
+    minItems: baseMinItems,
+    maxItems: baseMaxItems,
     minimum: baseMinimum,
     maximum: baseMaximum,
     description: baseDescription,
@@ -277,6 +295,8 @@ const mergeSchemaNodes = (
     pattern: overlayPattern,
     minLength: overlayMinLength,
     maxLength: overlayMaxLength,
+    minItems: overlayMinItems,
+    maxItems: overlayMaxItems,
     minimum: overlayMinimum,
     maximum: overlayMaximum,
     description: overlayDescription,
@@ -326,6 +346,11 @@ const mergeSchemaNodes = (
 
   if (mergedMinLength !== undefined && mergedMaxLength !== undefined && mergedMinLength > mergedMaxLength) return undefined
 
+  const mergedMinItems = mergeMinItems(baseMinItems, overlayMinItems)
+  const mergedMaxItems = mergeMaxItems(baseMaxItems, overlayMaxItems)
+
+  if (mergedMinItems !== undefined && mergedMaxItems !== undefined && mergedMinItems > mergedMaxItems) return undefined
+
   const mergedMinimum = mergeMinimum(baseMinimum, overlayMinimum)
   const mergedMaximum = mergeMaximum(baseMaximum, overlayMaximum)
 
@@ -363,6 +388,8 @@ const mergeSchemaNodes = (
     ...(mergedPattern !== undefined ? { pattern: mergedPattern } : {}),
     ...(mergedMinLength !== undefined ? { minLength: mergedMinLength } : {}),
     ...(mergedMaxLength !== undefined ? { maxLength: mergedMaxLength } : {}),
+    ...(mergedMinItems !== undefined ? { minItems: mergedMinItems } : {}),
+    ...(mergedMaxItems !== undefined ? { maxItems: mergedMaxItems } : {}),
     ...(mergedMinimum !== undefined ? { minimum: mergedMinimum } : {}),
     ...(mergedMaximum !== undefined ? { maximum: mergedMaximum } : {}),
     ...(overlayDescription || baseDescription ? { description: overlayDescription ?? baseDescription } : {}),

--- a/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.ts
+++ b/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.ts
@@ -1,9 +1,10 @@
 import _ from 'lodash'
-import { TFormSchemaNode, TFormSchemaProperties } from 'src/localTypes/formSchema'
+import { TFormSchemaNode, TFormSchemaOneOfBranch, TFormSchemaProperties } from 'src/localTypes/formSchema'
 
 type TV3FormSchemaNode = TFormSchemaNode & {
   allOf?: TV3FormSchemaNode[]
   oneOf?: TV3FormSchemaNode[]
+  not?: TV3FormSchemaNode
 }
 
 type TMergeOptions = {
@@ -16,6 +17,8 @@ const knownSchemaNodeKeys = new Set([
   'allOf',
   'oneOf',
   'oneOfRequiredGroups',
+  'oneOfBranches',
+  'not',
   'type',
   'properties',
   'items',
@@ -225,6 +228,7 @@ const mergeSchemaNodes = (
     required: baseRequired,
     enum: baseEnum,
     oneOfRequiredGroups: baseOneOfRequiredGroups,
+    oneOfBranches: baseOneOfBranches,
     default: baseDefault,
     example: baseExample,
     nullable: _baseNullable,
@@ -248,6 +252,7 @@ const mergeSchemaNodes = (
     required: overlayRequired,
     enum: overlayEnum,
     oneOfRequiredGroups: overlayOneOfRequiredGroups,
+    oneOfBranches: overlayOneOfBranches,
     default: overlayDefault,
     example: overlayExample,
     nullable: _overlayNullable,
@@ -283,6 +288,9 @@ const mergeSchemaNodes = (
 
   const mergedOneOfRequiredGroups = mergeStrictValue(baseOneOfRequiredGroups, overlayOneOfRequiredGroups)
   if (mergedOneOfRequiredGroups === MERGE_CONFLICT) return undefined
+
+  const mergedOneOfBranches = mergeStrictValue(baseOneOfBranches, overlayOneOfBranches)
+  if (mergedOneOfBranches === MERGE_CONFLICT) return undefined
 
   const mergedDefault = mergeAnnotationValue(baseDefault, overlayDefault, options)
   if (mergedDefault === MERGE_CONFLICT) return undefined
@@ -323,6 +331,7 @@ const mergeSchemaNodes = (
     ...(mergedRequired ? { required: mergedRequired } : {}),
     ...(mergedEnum ? { enum: mergedEnum } : {}),
     ...(mergedOneOfRequiredGroups !== undefined ? { oneOfRequiredGroups: mergedOneOfRequiredGroups } : {}),
+    ...(mergedOneOfBranches !== undefined ? { oneOfBranches: mergedOneOfBranches } : {}),
     ...(mergedDefault !== undefined ? { default: mergedDefault } : {}),
     ...(mergedExample !== undefined ? { example: mergedExample } : {}),
     ...(mergedNullable ? { nullable: mergedNullable } : {}),
@@ -418,10 +427,170 @@ const extractSupportedOneOfRequiredGroups = (node: TV3FormSchemaNode): string[][
   return groups
 }
 
+type TOneOfBranchExtractionResult =
+  | {
+      supported: true
+      branch: TFormSchemaOneOfBranch
+    }
+  | {
+      supported: false
+    }
+
+const isSupportedOneOfMatchValue = (value: unknown): value is string | number | boolean => {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+}
+
+const getUniqueStringList = (value: unknown): string[] | undefined => {
+  if (!Array.isArray(value) || value.length === 0) {
+    return undefined
+  }
+
+  if (value.some(item => typeof item !== 'string' || !item)) {
+    return undefined
+  }
+
+  return Array.from(new Set(value))
+}
+
+const hasDeclaredProperty = (properties: TFormSchemaProperties, key: string): boolean => {
+  return Object.prototype.hasOwnProperty.call(properties, key)
+}
+
+const extractSupportedOneOfPropertyMatch = (value: unknown): string | number | boolean | undefined => {
+  if (!isSchemaNode(value)) {
+    return undefined
+  }
+
+  const { enum: enumValues, ...rest } = value
+
+  if (Object.keys(rest).length > 0) {
+    return undefined
+  }
+
+  if (!Array.isArray(enumValues) || enumValues.length !== 1) {
+    return undefined
+  }
+
+  const [matchValue] = enumValues
+
+  return isSupportedOneOfMatchValue(matchValue) ? matchValue : undefined
+}
+
+const extractSupportedOneOfBranch = (
+  entry: unknown,
+  parentProperties: TFormSchemaProperties,
+): TOneOfBranchExtractionResult => {
+  if (!isSchemaNode(entry)) {
+    return { supported: false }
+  }
+
+  const { required, properties, not, ...rest } = entry
+
+  if (Object.keys(rest).length > 0) {
+    return { supported: false }
+  }
+
+  const requiredFields = getUniqueStringList(required)
+
+  if (!requiredFields || requiredFields.some(field => !hasDeclaredProperty(parentProperties, field))) {
+    return { supported: false }
+  }
+
+  const branch: TFormSchemaOneOfBranch = {
+    required: requiredFields,
+  }
+
+  if (properties !== undefined) {
+    const match: NonNullable<TFormSchemaOneOfBranch['match']> = {}
+
+    for (const [key, value] of Object.entries(properties)) {
+      if (!hasDeclaredProperty(parentProperties, key)) {
+        return { supported: false }
+      }
+
+      const matchValue = extractSupportedOneOfPropertyMatch(value)
+
+      if (matchValue === undefined) {
+        return { supported: false }
+      }
+
+      match[key] = matchValue
+    }
+
+    if (Object.keys(match).length > 0) {
+      branch.match = match
+    }
+  }
+
+  if (not !== undefined) {
+    if (!isSchemaNode(not)) {
+      return { supported: false }
+    }
+
+    const { required: notRequired, ...notRest } = not
+
+    if (Object.keys(notRest).length > 0) {
+      return { supported: false }
+    }
+
+    const forbiddenFields = getUniqueStringList(notRequired)
+
+    if (!forbiddenFields || forbiddenFields.some(field => !hasDeclaredProperty(parentProperties, field))) {
+      return { supported: false }
+    }
+
+    branch.forbidden = forbiddenFields
+  }
+
+  return {
+    supported: true,
+    branch,
+  }
+}
+
+const extractSupportedOneOfBranches = (node: TV3FormSchemaNode): TFormSchemaOneOfBranch[] | undefined => {
+  if (!Array.isArray(node.oneOf) || node.oneOf.length === 0) {
+    return undefined
+  }
+
+  if (node.type !== 'object' && !node.properties) {
+    return undefined
+  }
+
+  if (!node.properties || Object.keys(node.properties).length === 0) {
+    return undefined
+  }
+
+  const branches: TFormSchemaOneOfBranch[] = []
+
+  for (const entry of node.oneOf) {
+    const result = extractSupportedOneOfBranch(entry, node.properties)
+
+    if (!result.supported) {
+      return undefined
+    }
+
+    branches.push(result.branch)
+  }
+
+  return branches
+}
+
 const normalizeOneOf = (node: TV3FormSchemaNode): TV3FormSchemaNode => {
   const oneOfRequiredGroups = extractSupportedOneOfRequiredGroups(node)
 
-  if (!oneOfRequiredGroups) {
+  if (oneOfRequiredGroups) {
+    const { oneOf: _oneOf, ...nodeWithoutOneOf } = node
+
+    return {
+      ...nodeWithoutOneOf,
+      oneOfRequiredGroups,
+    }
+  }
+
+  const oneOfBranches = extractSupportedOneOfBranches(node)
+
+  if (!oneOfBranches) {
     return node
   }
 
@@ -429,7 +598,7 @@ const normalizeOneOf = (node: TV3FormSchemaNode): TV3FormSchemaNode => {
 
   return {
     ...nodeWithoutOneOf,
-    oneOfRequiredGroups,
+    oneOfBranches,
   }
 }
 

--- a/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.ts
+++ b/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.ts
@@ -28,6 +28,7 @@ const knownSchemaNodeKeys = new Set([
   'default',
   'example',
   'nullable',
+  'format',
   'pattern',
   'minLength',
   'maxLength',
@@ -264,6 +265,7 @@ const mergeSchemaNodes = (
     default: baseDefault,
     example: baseExample,
     nullable: _baseNullable,
+    format: baseFormat,
     pattern: basePattern,
     minLength: baseMinLength,
     maxLength: baseMaxLength,
@@ -292,6 +294,7 @@ const mergeSchemaNodes = (
     default: overlayDefault,
     example: overlayExample,
     nullable: _overlayNullable,
+    format: overlayFormat,
     pattern: overlayPattern,
     minLength: overlayMinLength,
     maxLength: overlayMaxLength,
@@ -341,6 +344,9 @@ const mergeSchemaNodes = (
   const mergedPattern = mergeStrictValue(basePattern, overlayPattern)
   if (mergedPattern === MERGE_CONFLICT) return undefined
 
+  const mergedFormat = mergeStrictValue(baseFormat, overlayFormat)
+  if (mergedFormat === MERGE_CONFLICT) return undefined
+
   const mergedMinLength = mergeMinLength(baseMinLength, overlayMinLength)
   const mergedMaxLength = mergeMaxLength(baseMaxLength, overlayMaxLength)
 
@@ -385,6 +391,7 @@ const mergeSchemaNodes = (
     ...(mergedDefault !== undefined ? { default: mergedDefault } : {}),
     ...(mergedExample !== undefined ? { example: mergedExample } : {}),
     ...(mergedNullable ? { nullable: mergedNullable } : {}),
+    ...(mergedFormat !== undefined ? { format: mergedFormat } : {}),
     ...(mergedPattern !== undefined ? { pattern: mergedPattern } : {}),
     ...(mergedMinLength !== undefined ? { minLength: mergedMinLength } : {}),
     ...(mergedMaxLength !== undefined ? { maxLength: mergedMaxLength } : {}),

--- a/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.ts
+++ b/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.ts
@@ -25,6 +25,9 @@ const knownSchemaNodeKeys = new Set([
   'default',
   'example',
   'nullable',
+  'pattern',
+  'minimum',
+  'maximum',
   'description',
   'customProps',
   'isAdditionalProperties',
@@ -69,6 +72,20 @@ const mergeEnum = (base?: string[], overlay?: string[]): string[] | typeof MERGE
   if (merged.length === 0) return MERGE_CONFLICT
 
   return merged
+}
+
+const mergeMinimum = (base?: number, overlay?: number): number | undefined => {
+  if (base === undefined) return overlay
+  if (overlay === undefined) return base
+
+  return Math.max(base, overlay)
+}
+
+const mergeMaximum = (base?: number, overlay?: number): number | undefined => {
+  if (base === undefined) return overlay
+  if (overlay === undefined) return base
+
+  return Math.min(base, overlay)
 }
 
 const mergeStrictValue = <T>(
@@ -211,6 +228,9 @@ const mergeSchemaNodes = (
     default: baseDefault,
     example: baseExample,
     nullable: _baseNullable,
+    pattern: basePattern,
+    minimum: baseMinimum,
+    maximum: baseMaximum,
     description: baseDescription,
     customProps: baseCustomProps,
     isAdditionalProperties: baseIsAdditionalProperties,
@@ -231,6 +251,9 @@ const mergeSchemaNodes = (
     default: overlayDefault,
     example: overlayExample,
     nullable: _overlayNullable,
+    pattern: overlayPattern,
+    minimum: overlayMinimum,
+    maximum: overlayMaximum,
     description: overlayDescription,
     customProps: overlayCustomProps,
     isAdditionalProperties: overlayIsAdditionalProperties,
@@ -267,6 +290,14 @@ const mergeSchemaNodes = (
   const mergedExample = mergeAnnotationValue(baseExample, overlayExample, options)
   if (mergedExample === MERGE_CONFLICT) return undefined
 
+  const mergedPattern = mergeStrictValue(basePattern, overlayPattern)
+  if (mergedPattern === MERGE_CONFLICT) return undefined
+
+  const mergedMinimum = mergeMinimum(baseMinimum, overlayMinimum)
+  const mergedMaximum = mergeMaximum(baseMaximum, overlayMaximum)
+
+  if (mergedMinimum !== undefined && mergedMaximum !== undefined && mergedMinimum > mergedMaximum) return undefined
+
   const mergedCustomProps = mergeStrictValue(baseCustomProps, overlayCustomProps)
   if (mergedCustomProps === MERGE_CONFLICT) return undefined
 
@@ -295,6 +326,9 @@ const mergeSchemaNodes = (
     ...(mergedDefault !== undefined ? { default: mergedDefault } : {}),
     ...(mergedExample !== undefined ? { example: mergedExample } : {}),
     ...(mergedNullable ? { nullable: mergedNullable } : {}),
+    ...(mergedPattern !== undefined ? { pattern: mergedPattern } : {}),
+    ...(mergedMinimum !== undefined ? { minimum: mergedMinimum } : {}),
+    ...(mergedMaximum !== undefined ? { maximum: mergedMaximum } : {}),
     ...(overlayDescription || baseDescription ? { description: overlayDescription ?? baseDescription } : {}),
     ...(mergedCustomProps !== undefined ? { customProps: mergedCustomProps } : {}),
     ...(mergedIsAdditionalProperties !== undefined ? { isAdditionalProperties: mergedIsAdditionalProperties } : {}),

--- a/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.ts
+++ b/src/endpoints/forms/prepareFormProps/utils/prepare/utils/normalizeV3SchemaForForms.ts
@@ -29,6 +29,8 @@ const knownSchemaNodeKeys = new Set([
   'example',
   'nullable',
   'pattern',
+  'minLength',
+  'maxLength',
   'minimum',
   'maximum',
   'description',
@@ -85,6 +87,20 @@ const mergeMinimum = (base?: number, overlay?: number): number | undefined => {
 }
 
 const mergeMaximum = (base?: number, overlay?: number): number | undefined => {
+  if (base === undefined) return overlay
+  if (overlay === undefined) return base
+
+  return Math.min(base, overlay)
+}
+
+const mergeMinLength = (base?: number, overlay?: number): number | undefined => {
+  if (base === undefined) return overlay
+  if (overlay === undefined) return base
+
+  return Math.max(base, overlay)
+}
+
+const mergeMaxLength = (base?: number, overlay?: number): number | undefined => {
   if (base === undefined) return overlay
   if (overlay === undefined) return base
 
@@ -233,6 +249,8 @@ const mergeSchemaNodes = (
     example: baseExample,
     nullable: _baseNullable,
     pattern: basePattern,
+    minLength: baseMinLength,
+    maxLength: baseMaxLength,
     minimum: baseMinimum,
     maximum: baseMaximum,
     description: baseDescription,
@@ -257,6 +275,8 @@ const mergeSchemaNodes = (
     example: overlayExample,
     nullable: _overlayNullable,
     pattern: overlayPattern,
+    minLength: overlayMinLength,
+    maxLength: overlayMaxLength,
     minimum: overlayMinimum,
     maximum: overlayMaximum,
     description: overlayDescription,
@@ -301,6 +321,11 @@ const mergeSchemaNodes = (
   const mergedPattern = mergeStrictValue(basePattern, overlayPattern)
   if (mergedPattern === MERGE_CONFLICT) return undefined
 
+  const mergedMinLength = mergeMinLength(baseMinLength, overlayMinLength)
+  const mergedMaxLength = mergeMaxLength(baseMaxLength, overlayMaxLength)
+
+  if (mergedMinLength !== undefined && mergedMaxLength !== undefined && mergedMinLength > mergedMaxLength) return undefined
+
   const mergedMinimum = mergeMinimum(baseMinimum, overlayMinimum)
   const mergedMaximum = mergeMaximum(baseMaximum, overlayMaximum)
 
@@ -336,6 +361,8 @@ const mergeSchemaNodes = (
     ...(mergedExample !== undefined ? { example: mergedExample } : {}),
     ...(mergedNullable ? { nullable: mergedNullable } : {}),
     ...(mergedPattern !== undefined ? { pattern: mergedPattern } : {}),
+    ...(mergedMinLength !== undefined ? { minLength: mergedMinLength } : {}),
+    ...(mergedMaxLength !== undefined ? { maxLength: mergedMaxLength } : {}),
     ...(mergedMinimum !== undefined ? { minimum: mergedMinimum } : {}),
     ...(mergedMaximum !== undefined ? { maximum: mergedMaximum } : {}),
     ...(overlayDescription || baseDescription ? { description: overlayDescription ?? baseDescription } : {}),

--- a/src/endpoints/forms/prepareFormProps/utils/prepare/utils/tryPrepareSchemaFromV3.test.ts
+++ b/src/endpoints/forms/prepareFormProps/utils/prepare/utils/tryPrepareSchemaFromV3.test.ts
@@ -278,6 +278,246 @@ describe('tryPrepareSchemaFromV3', () => {
     })
   })
 
+  it('returns success when oneOf branches are lowered into supported branch metadata', async () => {
+    mockedGetOpenApiV3Index.mockResolvedValue({
+      paths: {
+        'apis/demo.example.io/v1': {
+          serverRelativeURL: '/openapi/v3/apis/demo.example.io/v1?hash=abc',
+        },
+      },
+    })
+    mockedGetOpenApiV3ServerRelativeUrlFromIndex.mockReturnValue('/openapi/v3/apis/demo.example.io/v1?hash=abc')
+    mockedGetOpenApiV3Document.mockResolvedValue({
+      openapi: '3.0.0',
+      info: { title: 'demo', version: 'v1' },
+      paths: {
+        '/apis/demo.example.io/v1/widgets': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      kind: {
+                        type: 'string',
+                        enum: ['Widget'],
+                      },
+                      spec: {
+                        type: 'object',
+                        required: ['type'],
+                        properties: {
+                          type: {
+                            type: 'string',
+                            enum: ['service', 'url'],
+                          },
+                          service: {
+                            type: 'object',
+                            required: ['name', 'port'],
+                            properties: {
+                              name: {
+                                type: 'string',
+                              },
+                              port: {
+                                type: 'integer',
+                                minimum: 1,
+                                maximum: 65535,
+                              },
+                            },
+                          },
+                          url: {
+                            type: 'string',
+                            pattern: '^https?://',
+                          },
+                        },
+                        oneOf: [
+                          {
+                            required: ['service'],
+                            properties: {
+                              type: {
+                                enum: ['service'],
+                              },
+                            },
+                            not: {
+                              required: ['url'],
+                            },
+                          },
+                          {
+                            required: ['url'],
+                            properties: {
+                              type: {
+                                enum: ['url'],
+                              },
+                            },
+                            not: {
+                              required: ['service'],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as any)
+
+    const result = await tryPrepareSchemaFromV3({ data })
+
+    expect(result).toEqual({
+      source: 'v3',
+      status: 'success',
+      bodyParametersSchema: {
+        type: 'object',
+        properties: {
+          kind: {
+            type: 'string',
+            enum: ['Widget'],
+          },
+          spec: {
+            type: 'object',
+            required: ['type'],
+            properties: {
+              type: {
+                type: 'string',
+                enum: ['service', 'url'],
+              },
+              service: {
+                type: 'object',
+                required: ['name', 'port'],
+                properties: {
+                  name: {
+                    type: 'string',
+                  },
+                  port: {
+                    type: 'integer',
+                    minimum: 1,
+                    maximum: 65535,
+                  },
+                },
+              },
+              url: {
+                type: 'string',
+                pattern: '^https?://',
+              },
+            },
+            oneOfBranches: [
+              {
+                required: ['service'],
+                match: {
+                  type: 'service',
+                },
+                forbidden: ['url'],
+              },
+              {
+                required: ['url'],
+                match: {
+                  type: 'url',
+                },
+                forbidden: ['service'],
+              },
+            ],
+          },
+        },
+      },
+      isNamespaced: false,
+      kind: 'Widget',
+    })
+  })
+
+  it('returns unsupported when oneOf contains unsupported not constraints', async () => {
+    mockedGetOpenApiV3Index.mockResolvedValue({
+      paths: {
+        'apis/demo.example.io/v1': {
+          serverRelativeURL: '/openapi/v3/apis/demo.example.io/v1?hash=abc',
+        },
+      },
+    })
+    mockedGetOpenApiV3ServerRelativeUrlFromIndex.mockReturnValue('/openapi/v3/apis/demo.example.io/v1?hash=abc')
+    mockedGetOpenApiV3Document.mockResolvedValue({
+      openapi: '3.0.0',
+      info: { title: 'demo', version: 'v1' },
+      paths: {
+        '/apis/demo.example.io/v1/widgets': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      kind: {
+                        type: 'string',
+                        enum: ['Widget'],
+                      },
+                      spec: {
+                        type: 'object',
+                        properties: {
+                          type: {
+                            type: 'string',
+                            enum: ['service', 'url'],
+                          },
+                          service: {
+                            type: 'object',
+                          },
+                          url: {
+                            type: 'string',
+                          },
+                        },
+                        oneOf: [
+                          {
+                            required: ['service'],
+                            properties: {
+                              type: {
+                                enum: ['service'],
+                              },
+                            },
+                            not: {
+                              properties: {
+                                url: {
+                                  type: 'string',
+                                },
+                              },
+                            },
+                          },
+                          {
+                            required: ['url'],
+                            properties: {
+                              type: {
+                                enum: ['url'],
+                              },
+                            },
+                            not: {
+                              required: ['service'],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as any)
+
+    const result = await tryPrepareSchemaFromV3({ data })
+
+    expect(result).toEqual({
+      source: 'v3',
+      status: 'unsupported',
+      error: 'Unsupported OpenAPI v3 schema for auto-generated form: /apis/demo.example.io/v1/widgets',
+      issues: [{ keyword: 'oneOf', path: ['spec'] }],
+      isNamespaced: false,
+      kind: 'Widget',
+    })
+  })
+
   it('normalizes singleton metadata allOf wrappers before support check', async () => {
     mockedGetOpenApiV3Index.mockResolvedValue({
       paths: {

--- a/src/localTypes/formSchema.ts
+++ b/src/localTypes/formSchema.ts
@@ -14,6 +14,14 @@ export type TFormSchemaKnownType =
 
 type TFormSchemaLooseType = TFormSchemaKnownType | (string & {})
 
+export type TFormSchemaOneOfMatchValue = string | number | boolean
+
+export interface TFormSchemaOneOfBranch {
+  match?: Record<string, TFormSchemaOneOfMatchValue>
+  required?: string[]
+  forbidden?: string[]
+}
+
 /**
  * Normalized form-schema node produced by the BFF and consumed by the form UI.
  * It intentionally models only the subset of schema keywords the form stack
@@ -27,6 +35,7 @@ export interface TFormSchemaNode {
   required?: string[]
   enum?: string[]
   oneOfRequiredGroups?: string[][]
+  oneOfBranches?: TFormSchemaOneOfBranch[]
   default?: unknown
   example?: unknown
   nullable?: boolean

--- a/src/localTypes/formSchema.ts
+++ b/src/localTypes/formSchema.ts
@@ -30,6 +30,9 @@ export interface TFormSchemaNode {
   default?: unknown
   example?: unknown
   nullable?: boolean
+  pattern?: string
+  minimum?: number
+  maximum?: number
   description?: string
   customProps?: unknown
   isAdditionalProperties?: boolean

--- a/src/localTypes/formSchema.ts
+++ b/src/localTypes/formSchema.ts
@@ -40,6 +40,8 @@ export interface TFormSchemaNode {
   example?: unknown
   nullable?: boolean
   pattern?: string
+  minLength?: number
+  maxLength?: number
   minimum?: number
   maximum?: number
   description?: string

--- a/src/localTypes/formSchema.ts
+++ b/src/localTypes/formSchema.ts
@@ -42,6 +42,8 @@ export interface TFormSchemaNode {
   pattern?: string
   minLength?: number
   maxLength?: number
+  minItems?: number
+  maxItems?: number
   minimum?: number
   maximum?: number
   description?: string

--- a/src/localTypes/formSchema.ts
+++ b/src/localTypes/formSchema.ts
@@ -39,6 +39,7 @@ export interface TFormSchemaNode {
   default?: unknown
   example?: unknown
   nullable?: boolean
+  format?: string
   pattern?: string
   minLength?: number
   maxLength?: number


### PR DESCRIPTION
V3 OpenAPI миграция форм CRD: BFF нормализует и понижает поддерживаемые keywords (`oneOf` discriminated branches и required-groups, `pattern`, `minimum/maximum`, `minLength/maxLength`, `minItems/maxItems`, `format`) в плоский form-schema контракт; toolkit выводит соответствующие Ant Design валидаторы и UI-состояния (включая `toast` при автоочистке полей неактивных веток `oneOf`). Также `default` в `metadata.namespace` - `schema default` из CFO имеет приоритет над `namespace` из URL.

